### PR TITLE
Reversed operations to make mappers execute in same order as Enum/Stream

### DIFF
--- a/lib/gen_stage/flow.ex
+++ b/lib/gen_stage/flow.ex
@@ -483,7 +483,7 @@ defmodule GenStage.Flow do
   def materialize_for_stream(%{producers: {:enumerables, enumerables},
                                operations: operations}) do
 
-    {mappers, _reducers} = Enum.split_while(operations, &elem(&1, 0) == :mapper)
+    {mappers, _reducers} = Enum.split_while(Enum.reverse(operations), &elem(&1, 0) == :mapper)
 
     # TODO: choose if we will use partition dispatch if we have reducers
     stages =

--- a/test/gen_stage/flow_test.exs
+++ b/test/gen_stage/flow_test.exs
@@ -3,4 +3,12 @@ defmodule GenStage.FlowTest do
 
   alias Experimental.GenStage.Flow
   doctest Flow
+
+  test "mappers are performed in correct order" do
+    flow = Flow.from_enumerable(["a"])
+    |> Flow.map(fn(x) -> x <> "b" end)
+    |> Flow.map(fn(x) -> x <> "c" end)
+
+    assert Enum.to_list(flow) == ["abc"]
+  end
 end


### PR DESCRIPTION
It seems like the operations need to be reversed for the map/filter/flat_map/etc. calls to be ordered correctly.

Even if you don't merge this commit, you can look at this as an issue.

(Btw, thanks for your amazing work on gen_stage and the rest of the Elixir ecosystem! 👍 )