### PR TITLE
Fix GenStage.__using__/1 behaviour

### DIFF
--- a/lib/gen_stage.ex
+++ b/lib/gen_stage.ex
@@ -552,7 +552,7 @@ defmodule GenStage do
   @doc false
   defmacro __using__(_) do
     quote location: :keep do
-      @behaviour GenServer
+      @behaviour GenStage
 
       @doc false
       def handle_call(msg, _from, state) do


### PR DESCRIPTION
Fixes #63.

Looks like this was a typo.