### PR TITLE
Add a version requirement to inch_ex

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -22,7 +22,7 @@ defmodule GenStage.Mixfile do
 
   defp deps do
     [{:ex_doc, "~> 0.12", only: :docs},
-     {:inch_ex, only: :docs}]
+     {:inch_ex, ">= 0.4.0", only: :docs}]
   end
 
   defp package do


### PR DESCRIPTION
```
tobi@airship ~/github/gen_stage $ mix deps.get
inch_ex is missing its version requirement, use ">= 0.0.0" if it should match any version
Running dependency resolution
# magic
```

Gets rid of a warning. Have the 0.4.0 version from the mix.lock,
although I wonder if this should be checked in? (At least for
libraries et.al. in Ruby the rule was to not check in .lock
which sort of gets you to be more vigilant with your specified
version requirements (which is what users will get when installing).
Alas, here it doesn't matter as much as there are only docs
requirements no runtime deps)