### PR TITLE
fix milli-/micro-second consistency

### DIFF
--- a/lib/flow/window.ex
+++ b/lib/flow/window.ex
@@ -114,7 +114,7 @@ defmodule Flow.Window do
 
   Let's see example that will use the window above to count the frequency
   of words based on windows that are 1 hour long. The timestamps used by
-  Flow are integers in microseconds. For now we will also set the concurrency
+  Flow are integers in milliseconds. For now we will also set the concurrency
   down 1 and max demand down to 5 as it is simpler to reason about the results:
 
       iex> data = [{"elixir", 0}, {"elixir", 1_000}, {"erlang", 60_000},
@@ -206,7 +206,7 @@ defmodule Flow.Window do
   @typedoc """
   A function that retrieves the field to window by.
 
-  It must be an integer representing the time in microseconds.
+  It must be an integer representing the time in milliseconds.
   Flow does not care if the integer is using the UNIX epoch,
   Gregorian epoch or any other as long as it is consistent.
   """


### PR DESCRIPTION
Prior to this commit the documentation indicated that the resolution of
timer triggers was in microseconds; however, the code, in all the
examples and with the `to_ms` function indicated that the timer
resolution was, in fact, milliseconds. This becomes clearer upon
evaluating the timer doctest example, where it uses a window of 1 hour.
1 hour is 3_600_000 milliseconds, and consistent with the orders of
magnitude for the data elements (3_200_000, 4_000_000); however, 1 hour
in microseconds would have been 3_600_000_000, in which case *all* of
example data would have fallen into the first window. This commit
simply updates the documentation to reflect the de facto millisecond
resolution as indicated in multiple aspects of the code.