### PR TITLE
Support named partitions using enumerables

### DIFF
--- a/test/flow_test.exs
+++ b/test/flow_test.exs
@@ -453,7 +453,7 @@ defmodule FlowTest do
   describe "partition/2" do
     test "allows custom partitioning" do
       assert Flow.from_enumerables([[1, 2, 3], [4, 5, 6], 7..10])
-             |> Flow.partition(hash: fn x, _ -> {x, 0} end, stages: 4)
+             |> Flow.partition(hash: fn x -> {x, 0} end, stages: 4)
              |> Flow.reduce(fn -> [] end, &[&1 | &2])
              |> Flow.map_state(&[Enum.sort(&1)])
              |> Enum.sort() == [[], [], [], [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]]
@@ -514,7 +514,7 @@ defmodule FlowTest do
     end
 
     test "allows custom partitioning" do
-      assert merged_flows(stages: 4, min_demand: 5, hash: fn x, _ -> {x, 0} end)
+      assert merged_flows(stages: 4, min_demand: 5, hash: fn x -> {x, 0} end)
              |> Flow.reduce(fn -> [] end, &[&1 | &2])
              |> Flow.map_state(&[Enum.sum(&1)])
              |> Enum.sort() == [0, 0, 0, 10100]

--- a/test/gen_stage/partition_dispatcher_test.exs
+++ b/test/gen_stage/partition_dispatcher_test.exs
@@ -13,7 +13,7 @@ defmodule GenStage.PartitionDispatcherTest do
   test "subscribes, asks and cancels" do
     pid  = self()
     ref  = make_ref()
-    disp = dispatcher(partitions: 2)
+    disp = dispatcher(partitions: 0..1)
 
     # Subscribe, ask and cancel and leave some demand
     {:ok, 0, disp}  = D.subscribe([partition: 0], {pid, ref}, disp)
@@ -33,7 +33,7 @@ defmodule GenStage.PartitionDispatcherTest do
   test "subscribes, asks and dispatches" do
     pid  = self()
     ref  = make_ref()
-    disp = dispatcher(partitions: 2)
+    disp = dispatcher(partitions: 0..1)
     {:ok, 0, disp} = D.subscribe([partition: 0], {pid, ref}, disp)
 
     {:ok, 3, disp} = D.ask(3, {pid, ref}, disp)
@@ -50,7 +50,7 @@ defmodule GenStage.PartitionDispatcherTest do
   end
 
   test "buffers events before subscription" do
-    disp = dispatcher(partitions: 2)
+    disp = dispatcher(partitions: 0..1)
 
     # Use one subscription to queue
     pid = self()
@@ -78,7 +78,7 @@ defmodule GenStage.PartitionDispatcherTest do
   end
 
   test "buffers events after subscription" do
-    disp = dispatcher(partitions: 2)
+    disp = dispatcher(partitions: 0..1)
 
     pid0 = self()
     ref0 = make_ref()
@@ -105,7 +105,7 @@ defmodule GenStage.PartitionDispatcherTest do
   end
 
   test "subscribes, asks and cancels with buffer" do
-    disp = dispatcher(partitions: 2)
+    disp = dispatcher(partitions: 0..1)
 
     pid1 = self()
     ref1 = make_ref()
@@ -131,7 +131,7 @@ defmodule GenStage.PartitionDispatcherTest do
     ref0 = make_ref()
     pid1  = self()
     ref1 = make_ref()
-    disp = dispatcher(partitions: 2)
+    disp = dispatcher(partitions: 0..1)
 
     {:ok, 0, disp} = D.subscribe([partition: 0], {pid0, ref0}, disp)
     {:ok, 0, disp} = D.subscribe([partition: 1], {pid1, ref1}, disp)
@@ -149,7 +149,7 @@ defmodule GenStage.PartitionDispatcherTest do
     ref0 = make_ref()
     pid1 = self()
     ref1 = make_ref()
-    disp = dispatcher(partitions: 2)
+    disp = dispatcher(partitions: 0..1)
 
     {:ok, disp} = D.notify(:hello, disp)
     refute_received {:"$gen_consumer", {_, ^ref0}, {:notification, :hello}}
@@ -172,7 +172,7 @@ defmodule GenStage.PartitionDispatcherTest do
     ref0 = make_ref()
     pid1 = self()
     ref1 = make_ref()
-    disp = dispatcher(partitions: 2)
+    disp = dispatcher(partitions: 0..1)
 
     {:ok, 0, disp}  = D.subscribe([partition: 0], {pid0, ref0}, disp)
     {:ok, 0, disp}  = D.subscribe([partition: 1], {pid0, ref1}, disp)
@@ -192,7 +192,7 @@ defmodule GenStage.PartitionDispatcherTest do
   end
 
   test "errors on init" do
-    assert_raise ArgumentError, ~r/the number of :partitions is required/, fn ->
+    assert_raise ArgumentError, ~r/the enumerable of :partitions is required/, fn ->
       dispatcher([])
     end
   end
@@ -200,7 +200,7 @@ defmodule GenStage.PartitionDispatcherTest do
   test "errors on subscribe" do
     pid = self()
     ref = make_ref()
-    disp = dispatcher([partitions: 2])
+    disp = dispatcher([partitions: 0..1])
 
     assert_raise ArgumentError, ~r/the :partition option is required when subscribing/, fn ->
       D.subscribe([], {pid, ref}, disp)
@@ -211,15 +211,15 @@ defmodule GenStage.PartitionDispatcherTest do
       D.subscribe([partition: 0], {pid, ref}, disp)
     end
 
-    assert_raise ArgumentError, ~r/:partition must be an integer between 0..1/, fn ->
+    assert_raise ArgumentError, ~r/:partition must be one of 0, 1/, fn ->
       D.subscribe([partition: -1], {pid, ref}, disp)
     end
 
-    assert_raise ArgumentError, ~r/:partition must be an integer between 0..1/, fn ->
+    assert_raise ArgumentError, ~r/:partition must be one of 0, 1/, fn ->
       D.subscribe([partition: 2], {pid, ref}, disp)
     end
 
-    assert_raise ArgumentError, ~r/:partition must be an integer between 0..1/, fn ->
+    assert_raise ArgumentError, ~r/:partition must be one of 0, 1/, fn ->
       D.subscribe([partition: :oops], {pid, ref}, disp)
     end
   end


### PR DESCRIPTION
This is a breaking change! It makes it easier to partition events between stages when hashing is not appropriate, and documents `:partition` subscribe option which is required when using partitions.

/cc @cloud8421