### PR TITLE
Fix 2 typos.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 
 ### Bug fixes
 
-  * Ensure uneven partitions emits all windowws on `Flow.departition/4`
+  * Ensure uneven partitions emits all windows on `Flow.departition/4`
   * Properly emit the beginning of the window time on triggers for fixed windows
 
 ## v0.6.1 (2016-10-05)

--- a/lib/flow.ex
+++ b/lib/flow.ex
@@ -839,7 +839,7 @@ defmodule Flow do
       that receives a single argument: the event and must return its key.
       To facilitate customization, `:key` also allows common values, such as
       `{:elem, integer}` and `{:key, atom}, to calculate the hash based on a
-      tuple or a map field. See the "Keu shortcuts" section below.
+      tuple or a map field. See the "Key shortcuts" section below.
     * `:hash` - the hashing function. By default a hashing function is built
       on the key but a custom one may be specified as described in
       `GenStage.PartitionDispatcher`


### PR DESCRIPTION
"windowws" -> "windows"
"Keu" -> "Key"