### PR TITLE
Selective Broadcast dispatches

### DIFF
--- a/lib/gen_stage.ex
+++ b/lib/gen_stage.ex
@@ -1139,11 +1139,6 @@ defmodule GenStage do
       cancellations, the reason is wrapped in a `:cancel` tuple.
     * `:min_demand` - the minimum demand for this subscription
     * `:max_demand` - the maximum demand for this subscription
-    * `:selector` - a function (event :: any -> boolean)
-                    which is used in the dispatcher to filter events
-                    destinated to the consumer. This option is relevant only when
-                    subscribing to producers using BroadcastDispatcher. See the dispatcher
-                    documentation for event-selection examples.
 
   All other options are sent as is to the producer stage.
   """

--- a/lib/gen_stage.ex
+++ b/lib/gen_stage.ex
@@ -1106,11 +1106,6 @@ defmodule GenStage do
       cancellations, the reason is wrapped in a `:cancel` tuple.
     * `:min_demand` - the minimum demand for this subscription
     * `:max_demand` - the maximum demand for this subscription
-    * `:selector` - a function (event :: any -> boolean)
-                    which is used in the dispatcher to filter events
-                    destinated to the consumer. This option is relevant only when
-                    subscribing to producers using BroadcastDispatcher. See the dispatcher
-                    documentation for event-selection examples.
 
   All other options are sent as is to the producer stage.
   """

--- a/lib/gen_stage.ex
+++ b/lib/gen_stage.ex
@@ -1106,6 +1106,11 @@ defmodule GenStage do
       cancellations, the reason is wrapped in a `:cancel` tuple.
     * `:min_demand` - the minimum demand for this subscription
     * `:max_demand` - the maximum demand for this subscription
+    * `:selector` - a function (event :: any -> boolean)
+                    which is used in the dispatcher to filter events
+                    destinated to the consumer. This option is relevant only when
+                    subscribing to producers using BroadcastDispatcher. See the dispatcher
+                    documentation for event-selection examples.
 
   All other options are sent as is to the producer stage.
   """
@@ -1134,6 +1139,11 @@ defmodule GenStage do
       cancellations, the reason is wrapped in a `:cancel` tuple.
     * `:min_demand` - the minimum demand for this subscription
     * `:max_demand` - the maximum demand for this subscription
+    * `:selector` - a function (event :: any -> boolean)
+                    which is used in the dispatcher to filter events
+                    destinated to the consumer. This option is relevant only when
+                    subscribing to producers using BroadcastDispatcher. See the dispatcher
+                    documentation for event-selection examples.
 
   All other options are sent as is to the producer stage.
   """

--- a/lib/gen_stage/broadcast_dispatcher.ex
+++ b/lib/gen_stage/broadcast_dispatcher.ex
@@ -4,6 +4,21 @@ defmodule GenStage.BroadcastDispatcher do
   @moduledoc """
   A dispatcher that accumulates demand from all consumers
   before broadcasting events to all of them.
+
+  If a producer uses BroadcastDispatcher, its subscribers can specify
+  an optional `:selector` function of type (event :: any -> boolean)
+  at subscription time.
+
+  Assume `producer` and `consumer` are stages exchanging events of type
+  `%{ :key => String.t, any => any}`, then by specifying
+
+      GenStage.sync_subscribe(producer,
+        to: producer,
+        selector: fn %{key: key} -> String.starts_with?(key, "foo-") end)
+
+  `consumer` will receive events from `producer` only if the condition specified
+  in the selector function returns true.
+
   """
 
   @behaviour GenStage.Dispatcher
@@ -15,15 +30,16 @@ defmodule GenStage.BroadcastDispatcher do
 
   @doc false
   def notify(msg, {demands, _} = state) do
-    Enum.each(demands, fn {_, pid, ref} ->
+    Enum.each(demands, fn {_, pid, ref, _selector} ->
       Process.send(pid, {:"$gen_consumer", {self(), ref}, {:notification, msg}}, [:noconnect])
     end)
     {:ok, state}
   end
 
   @doc false
-  def subscribe(_opts, {pid, ref}, {demands, waiting}) do
-    {:ok, 0, {add_demand(-waiting, pid, ref, demands), waiting}}
+  def subscribe(opts, {pid, ref}, {demands, waiting}) do
+    {:ok, selector} = validate_selector(opts)
+    {:ok, 0, {add_demand(-waiting, pid, ref, selector, demands), waiting}}
   end
 
   @doc false
@@ -38,8 +54,8 @@ defmodule GenStage.BroadcastDispatcher do
 
   @doc false
   def ask(counter, {pid, ref}, {demands, waiting}) do
-    {current, demands} = pop_demand(ref, demands)
-    demands = add_demand(current + counter, pid, ref, demands)
+    {{current, selector}, demands} = pop_demand(ref, demands)
+    demands = add_demand(current + counter, pid, ref, selector, demands)
     new_min = get_min(demands)
     demands = adjust_demand(new_min, demands)
     {:ok, new_min, {demands, waiting + new_min}}
@@ -54,17 +70,29 @@ defmodule GenStage.BroadcastDispatcher do
     {deliver_now, deliver_later, waiting} =
       split_events(events, length, waiting)
 
-    Enum.each(demands, fn {_, pid, ref} ->
-      Process.send(pid, {:"$gen_consumer", {self(), ref}, deliver_now}, [:noconnect])
+    Enum.each(demands, fn {_, pid, ref, selector} ->
+      selected = if selector, do: Enum.filter(deliver_now, selector), else: deliver_now
+      Process.send(pid, {:"$gen_consumer", {self(), ref}, selected}, [:noconnect])
     end)
 
     {:ok, deliver_later, {demands, waiting}}
   end
 
+  defp validate_selector(opts) do
+    case Keyword.get(opts, :selector) do
+      nil -> {:ok, nil}
+      selector when is_function(selector, 1) ->
+        {:ok, selector}
+      something_else ->
+        :error_logger.error_msg(':selector option must be passed a unary function and not: ~p~n', [something_else])
+        {:error, :not_a_unary_function}
+    end
+  end
+
   defp get_min([]),
     do: 0
-  defp get_min([{acc, _, _} | demands]),
-    do: demands |> Enum.reduce(acc, fn {val, _, _}, acc -> min(val, acc) end) |> max(0)
+  defp get_min([{acc, _, _, _} | demands]),
+    do: demands |> Enum.reduce(acc, fn {val, _, _, _}, acc -> min(val, acc) end) |> max(0)
 
   defp split_events(events, length, counter) when length <= counter do
     {events, [], counter - length}
@@ -77,16 +105,17 @@ defmodule GenStage.BroadcastDispatcher do
   defp adjust_demand(0, demands),
     do: demands
   defp adjust_demand(min, demands),
-    do: Enum.map(demands, fn {counter, pid, key} -> {counter - min, pid, key} end)
+    do: Enum.map(demands, fn {counter, pid, key, selector} -> {counter - min, pid, key, selector} end)
 
-  defp add_demand(counter, pid, ref, demands) when is_integer(counter) and is_pid(pid) do
-    [{counter, pid, ref} | demands]
+  defp add_demand(counter, pid, ref, selector, demands)
+  when is_integer(counter) and is_pid(pid) and (is_nil(selector) or is_function(selector, 1)) do
+    [{counter, pid, ref, selector} | demands]
   end
 
   defp pop_demand(ref, demands) do
     case List.keytake(demands, ref, 2) do
-      {{current, _pid, ^ref}, rest} -> {current, rest}
-      nil -> {0, demands}
+      {{current, _pid, ^ref, selector}, rest} -> {{current, selector}, rest}
+      nil -> {{0, nil}, demands}
     end
   end
 

--- a/test/gen_stage/broadcast_dispatcher_test.exs
+++ b/test/gen_stage/broadcast_dispatcher_test.exs
@@ -16,7 +16,7 @@ defmodule GenStage.BroadcastDispatcherTest do
     disp = dispatcher([])
 
     {:ok, 0, disp} = D.subscribe([], {pid, ref}, disp)
-    assert disp == {[{0, pid, ref}], 0}
+    assert disp == {[{0, pid, ref, nil}], 0}
 
     {:ok, 0, disp} = D.cancel({pid, ref}, disp)
     assert disp == {[], 0}
@@ -29,19 +29,19 @@ defmodule GenStage.BroadcastDispatcherTest do
     disp = dispatcher([])
 
     {:ok, 0, disp} = D.subscribe([], {pid, ref1}, disp)
-    assert disp == {[{0, pid, ref1}], 0}
+    assert disp == {[{0, pid, ref1, nil}], 0}
 
     {:ok, 10, disp} = D.ask(10, {pid, ref1}, disp)
-    assert disp == {[{0, pid, ref1}], 10}
+    assert disp == {[{0, pid, ref1, nil}], 10}
 
     {:ok, 0, disp} = D.subscribe([], {pid, ref2}, disp)
-    assert disp == {[{-10, pid, ref2}, {0, pid, ref1}], 10}
+    assert disp == {[{-10, pid, ref2, nil}, {0, pid, ref1, nil}], 10}
 
     {:ok, 0, disp} = D.cancel({pid, ref1}, disp)
-    assert disp == {[{-10, pid, ref2}], 10}
+    assert disp == {[{-10, pid, ref2, nil}], 10}
 
     {:ok, 0, disp} = D.ask(10, {pid, ref2}, disp)
-    assert disp == {[{0, pid, ref2}], 10}
+    assert disp == {[{0, pid, ref2, nil}], 10}
   end
 
   test "multiple subscriptions with late demand" do
@@ -51,19 +51,19 @@ defmodule GenStage.BroadcastDispatcherTest do
     disp = dispatcher([])
 
     {:ok, 0, disp} = D.subscribe([], {pid, ref1}, disp)
-    assert disp == {[{0, pid, ref1}], 0}
+    assert disp == {[{0, pid, ref1, nil}], 0}
 
     {:ok, 0, disp} = D.subscribe([], {pid, ref2}, disp)
-    assert disp == {[{0, pid, ref2}, {0, pid, ref1}], 0}
+    assert disp == {[{0, pid, ref2, nil}, {0, pid, ref1, nil}], 0}
 
     {:ok, 0, disp} = D.ask(10, {pid, ref1}, disp)
-    assert disp == {[{10, pid, ref1}, {0, pid, ref2}], 0}
+    assert disp == {[{10, pid, ref1, nil}, {0, pid, ref2, nil}], 0}
 
     {:ok, 10, disp} = D.cancel({pid, ref2}, disp)
-    assert disp == {[{0, pid, ref1}], 10}
+    assert disp == {[{0, pid, ref1, nil}], 10}
 
     {:ok, 10, disp} = D.ask(10, {pid, ref1}, disp)
-    assert disp == {[{0, pid, ref1}], 20}
+    assert disp == {[{0, pid, ref1, nil}], 20}
   end
 
   test "subscribes, asks and dispatches to multiple consumers" do
@@ -78,31 +78,35 @@ defmodule GenStage.BroadcastDispatcherTest do
 
     {:ok, 0, disp} = D.ask(3, {pid, ref1}, disp)
     {:ok, 2, disp} = D.ask(2, {pid, ref2}, disp)
-    assert disp == {[{0, pid, ref2}, {1, pid, ref1}], 2}
+    assert disp == {[{0, pid, ref2, nil}, {1, pid, ref1, nil}], 2}
 
     # One batch fits all
     {:ok, [], disp} = D.dispatch([:a, :b], 2, disp)
-    assert disp == {[{0, pid, ref2}, {1, pid, ref1}], 0}
+    assert disp == {[{0, pid, ref2, nil}, {1, pid, ref1, nil}], 0}
+
     assert_received {:"$gen_consumer", {_, ^ref1}, [:a, :b]}
     assert_received {:"$gen_consumer", {_, ^ref2}, [:a, :b]}
 
     # A batch with left-over
     {:ok, 1, disp} = D.ask(2, {pid, ref2}, disp)
+
     {:ok, [:d], disp} = D.dispatch([:c, :d], 2, disp)
-    assert disp == {[{1, pid, ref2}, {0, pid, ref1}], 0}
+    assert disp == {[{1, pid, ref2, nil}, {0, pid, ref1, nil}], 0}
     assert_received {:"$gen_consumer", {_, ^ref1}, [:c]}
     assert_received {:"$gen_consumer", {_, ^ref2}, [:c]}
 
     # A batch with no demand
+
     {:ok, [:d], disp} = D.dispatch([:d], 1, disp)
-    assert disp == {[{1, pid, ref2}, {0, pid, ref1}], 0}
+    assert disp == {[{1, pid, ref2, nil}, {0, pid, ref1, nil}], 0}
     refute_received {:"$gen_consumer", {_, _}, _}
 
     # Add a late subscriber
     {:ok, 1, disp} = D.ask(1, {pid, ref1}, disp)
     {:ok, 0, disp} = D.subscribe([], {pid, ref3}, disp)
-    assert disp == {[{-1, pid, ref3}, {0, pid, ref1}, {0, pid, ref2}], 1}
     {:ok, [:e], disp} = D.dispatch([:d, :e], 2, disp)
+
+    assert disp == {[{-1, pid, ref3, nil}, {0, pid, ref1, nil}, {0, pid, ref2, nil}], 0}
     assert_received {:"$gen_consumer", {_, ^ref1}, [:d]}
     assert_received {:"$gen_consumer", {_, ^ref2}, [:d]}
     assert_received {:"$gen_consumer", {_, ^ref3}, [:d]}
@@ -112,10 +116,31 @@ defmodule GenStage.BroadcastDispatcherTest do
     {:ok, 0, disp} = D.ask(2, {pid, ref2}, disp)
     {:ok, 2, disp} = D.ask(3, {pid, ref3}, disp)
     {:ok, [], disp} = D.dispatch([:e, :f], 2, disp)
-    assert disp == {[{0, pid, ref3}, {0, pid, ref2}, {0, pid, ref1}], 0}
+    assert disp == {[{0, pid, ref3, nil}, {0, pid, ref2, nil}, {0, pid, ref1, nil}], 0}
+
     assert_received {:"$gen_consumer", {_, ^ref1}, [:e, :f]}
     assert_received {:"$gen_consumer", {_, ^ref2}, [:e, :f]}
     assert_received {:"$gen_consumer", {_, ^ref3}, [:e, :f]}
+  end
+
+  test "subscribing with a selector function" do
+    pid  = self()
+    ref1 = make_ref()
+    ref2 = make_ref()
+    disp = dispatcher([])
+    selector1 = fn %{key: key} -> String.starts_with?(key, "pre") end
+    selector2 = fn %{key: key} -> String.starts_with?(key, "pref") end
+
+    {:ok, 0, disp} = D.subscribe([selector: selector1], {pid, ref1}, disp)
+    {:ok, 0, disp} = D.subscribe([selector: selector2], {pid, ref2}, disp)
+    assert {[{0, ^pid, ^ref2, _selector2}, {0, ^pid, ^ref1, _selector1}], 0} = disp
+    {:ok, 0, disp} = D.ask(4, {pid, ref2}, disp)
+    {:ok, 4, disp} = D.ask(4, {pid, ref1}, disp)
+
+    {:ok, [], _disp} = D.dispatch([%{key: "pref-1234"}, %{key: "pref-5678"}, %{key: "pre0000"}, %{key: "foo0000"}], 4, disp)
+
+    assert_received {:"$gen_consumer", {_, ^ref2}, [%{key: "pref-1234"}, %{key: "pref-5678"}]}
+    assert_received {:"$gen_consumer", {_, ^ref1}, [%{key: "pref-1234"}, %{key: "pref-5678"}, %{key: "pre0000"}]}
   end
 
   test "delivers notifications to all consumers" do


### PR DESCRIPTION
- GenStage sync_subscribe/3 and async_subscribe/2 can be given an
  extra :selector (any -> boolean) option which will filter messages
  destinated to the consumer.

- selector defaults to nil. Adding some docs
- BroadcastDispatcher unit tests