### PR TITLE
update spec for producers to handle flows

### DIFF
--- a/lib/flow.ex
+++ b/lib/flow.ex
@@ -412,7 +412,8 @@ defmodule Flow do
   @typep producers :: nil |
                       {:stages, GenStage.stage} |
                       {:enumerables, Enumerable.t} |
-                      {:join, t, t, fun(), fun(), fun()}
+                      {:join, t, t, fun(), fun(), fun()} |
+                      {:flows, [t]}
 
   @typep operation :: {:mapper, atom(), [term()]} |
                       {:partition, keyword()} |


### PR DESCRIPTION
Ran into this dialyzer issue via

```The call 'Elixir.Experimental.Flow':reduce(#{'__struct__':='Elixir.Experimental.Flow', 'operations':=[], 'options':=_, 'producers':={'flows',nonempty_maybe_improper_list()}, 'window':=_},fun(() -> any()),fun((_,_) -> atom() | ets:tid())) breaks the contract (t(),fun(() -> acc),fun((term(),acc) -> acc)) -> t() when acc :: term()```