### PR TITLE
proposal for more example in documentation

### DIFF
--- a/lib/gen_stage.ex
+++ b/lib/gen_stage.ex
@@ -1119,6 +1119,11 @@ defmodule GenStage do
       cancellations, the reason is wrapped in a `:cancel` tuple.
     * `:min_demand` - the minimum demand for this subscription
     * `:max_demand` - the maximum demand for this subscription
+    * `:selector` - If a producer uses BroadcastDispatcher, 
+      an optional :selector function of type (event :: any -> boolean)
+      limits this subscription to receiving only those events where the selector
+      function returns a truthy value.
+
 
   All other options are sent as is to the producer stage.
   """

--- a/lib/gen_stage/broadcast_dispatcher.ex
+++ b/lib/gen_stage/broadcast_dispatcher.ex
@@ -20,7 +20,14 @@ defmodule GenStage.BroadcastDispatcher do
   for which the selector function returns a truthy value.
 
   The `:selector` option can be specified in sync and async subscriptions,
-  as well as in the `:subscribe_to` list in the return tuple of `c:GenStage.init/1`
+  as well as in the `:subscribe_to` list in the return tuple of `c:GenStage.init/1`.
+  For example:
+
+      def init(:ok) do
+        {:consumer, :ok, subscribe_to: 
+          [{producer, selector: fn %{key: key} -> String.starts_with?(key, "foo-") end}]}`
+      end
+
   """
 
   @behaviour GenStage.Dispatcher


### PR DESCRIPTION
Documentation in broadcast_dispatcher doesn't give an example of how to include the :selector in the tuple options in `:subscribe_to`.  That leads me to look at the documentation for GenStage.init/1, where I find 
```
:subscribe_to - a list of producers to subscribe to. 
Each element represents the producer or a tuple
 with the producer and the subscription 
options (as defined in sync_subscribe/2)
```
So I look for the documentation for sync_subscribe/2, and I still don't see any mention of :selector.

Here is my best guess at what the documentation could look like to be more helpful.  I'm trying to lift this great functionality to the surface, but please correct me if this is incorrect or inappropriate to do this.