### PR TITLE
Typos in documentation. s/dispacher/dispatcher/g

### DIFF
--- a/lib/gen_stage.ex
+++ b/lib/gen_stage.ex
@@ -756,7 +756,7 @@ defmodule GenStage do
   When using a `:producer` or `:producer_consumer`, the dispatcher
   may be configured on init as follows:
 
-      {:producer, state, dispacher: GenStage.BroadcastDispatcher}
+      {:producer, state, dispatcher: GenStage.BroadcastDispatcher}
 
   Some dispatchers may require options to be given on initialization,
   those can be done with a tuple:

--- a/lib/gen_stage/dispatcher.ex
+++ b/lib/gen_stage/dispatcher.ex
@@ -8,7 +8,7 @@ defmodule GenStage.Dispatcher do
   When using a `:producer` or `:producer_consumer`, the dispatcher
   may be configured on init as follows:
 
-      {:producer, state, dispacher: GenStage.BroadcastDispatcher}
+      {:producer, state, dispatcher: GenStage.BroadcastDispatcher}
 
   Some dispatchers may require options to be given on initialization,
   those can be done with a tuple:


### PR DESCRIPTION
Simple typo in the documentation in two places.

Following the docs produces:
iex(1)> {:ok, pid} = EVStream.GenP.start_link
** (EXIT from #PID<0.171.0>) {:bad_opts, "unknown options [dispacher: Experimental.GenStage.BroadcastDispatcher]"}

Thanks.