### PR TITLE
Accumulate demands, but don't sum them together.

### DIFF
--- a/lib/gen_stage.ex
+++ b/lib/gen_stage.ex
@@ -2092,6 +2092,7 @@ defmodule GenStage do
       [] -> {:noreply, stage}
       demands when is_list(demands) ->
         demands
+        |> :lists.reverse
         |> Enum.reduce({:noreply, stage},
                        fn(d, {:noreply, %{state: state} = stage}) ->
                            noreply_callback(:handle_demand, [d, state], stage)
@@ -2166,7 +2167,7 @@ defmodule GenStage do
           %{events: :forward, state: state} ->
             noreply_callback(:handle_demand, [counter, state], stage)
           %{events: events} when is_list(events) ->
-            {:noreply, %{stage | events: events ++ [counter]}}
+            {:noreply, %{stage | events: [counter|events]}}
           %{events: queue} -> # producer_consumer
             take_pc_events(queue, counter, stage)
         end


### PR DESCRIPTION
This should allow slow producers to satisfy initial small demands,
instead of trying to satisfy one large demand which could accumulate
while many subscribers start up.

Fixes #136.

Example code used to demonstrate the issue is at https://gist.github.com/lmarlow/c6d4ed14f55f3f7026aecb926e63e8ba.

I'm not real happy with the solution, but it works. I would love feedback.