### PR TITLE
Namespace ConsumerSupervisor as GenStage.ConsumerSupervisor

### DIFF
--- a/examples/dynamic_supervisor.exs
+++ b/examples/dynamic_supervisor.exs
@@ -34,10 +34,10 @@ defmodule Consumer do
   spawn printer tasks for each event.
   """
 
-  use ConsumerSupervisor
+  use GenStage.ConsumerSupervisor
 
   def start_link() do
-    ConsumerSupervisor.start_link(__MODULE__, :ok)
+    GenStage.ConsumerSupervisor.start_link(__MODULE__, :ok)
   end
 
   # Callbacks

--- a/lib/consumer_supervisor.ex
+++ b/lib/consumer_supervisor.ex
@@ -1,4 +1,4 @@
-defmodule ConsumerSupervisor do
+defmodule GenStage.ConsumerSupervisor do
   @moduledoc ~S"""
   A supervisor that starts children as events flow in.
 
@@ -27,14 +27,14 @@ defmodule ConsumerSupervisor do
   incoming event to the terminal.
 
       defmodule Consumer do
-        use ConsumerSupervisor
+        use GenStage.ConsumerSupervisor
 
         def start_link() do
           children = [
             worker(Printer, [], restart: :temporary)
           ]
 
-          ConsumerSupervisor.start_link(children, strategy: :one_for_one,
+          GenStage.ConsumerSupervisor.start_link(children, strategy: :one_for_one,
                                                   subscribe_to: [{Producer, max_demand: 50}])
         end
       end
@@ -100,7 +100,7 @@ defmodule ConsumerSupervisor do
   @doc false
   defmacro __using__(_) do
     quote location: :keep do
-      @behaviour ConsumerSupervisor
+      @behaviour GenStage.ConsumerSupervisor
       import Supervisor.Spec
     end
   end
@@ -250,7 +250,7 @@ defmodule ConsumerSupervisor do
       {:ok, children, opts} ->
         case validate_specs(children) do
           :ok ->
-            state = %ConsumerSupervisor{mod: mod, args: args, name: name || {self(), mod}}
+            state = %GenStage.ConsumerSupervisor{mod: mod, args: args, name: name || {self(), mod}}
             case init(state, children, opts) do
               {:ok, state, opts} -> {:consumer, state, opts}
               {:error, message} -> {:stop, {:bad_opts, message}}

--- a/test/consumer_supervisor_test.exs
+++ b/test/consumer_supervisor_test.exs
@@ -2,6 +2,7 @@ defmodule ConsumerSupervisorTest do
   use ExUnit.Case, async: true
 
   import Supervisor.Spec
+  alias GenStage.ConsumerSupervisor
 
   defmodule Simple do
     def init(args), do: args


### PR DESCRIPTION
This PR is presented for comment - not namespacing this module caused me
some confusion when I upgraded an app from using `DynamicSupervisor`, as
I just assumed that it would be namespaced and was surprised when it
wasn't, perhaps because `DynamicSupervisor` was buried under the
`Experimental` namespace prior to this latest version. The more I've
thought about it the more I think it makes sense, but I'm interested to
see what others think.