### PR TITLE
For discussion, an instrumentation spike

### DIFF
--- a/.iex.exs
+++ b/.iex.exs
@@ -1,0 +1,92 @@
+defmodule GenStageConsoleWatcher do
+  defmacro __using__(_) do
+    quote location: :keep do
+      def handle_metrics(:handle_events, [data|t], stageinfo) do
+        IO.puts "#{stageinfo.mod} got events! #{length(data)} of them"
+        {:noreply}
+      end
+
+      def handle_metrics(:handle_subscribe, [:consumer], stageinfo) do
+        count = stageinfo.consumers |> Map.keys |> length
+        IO.puts "#{stageinfo.mod} got a new subscriber! We got #{count} so far!"
+        {:noreply}
+      end
+
+      def handle_metrics(:handle_subscribe, [:producer], stageinfo) do
+        IO.puts "#{stageinfo.mod} subscribed successfully!"
+        {:noreply}
+      end
+
+      def handle_metrics(:handle_demand, [demanded, owed], stageinfo) do
+        IO.puts "#{stageinfo.mod} got demand! Was asked #{demanded}, but #{owed} so far"
+        {:noreply}
+      end
+    end
+  end
+end
+
+defmodule A do
+  use GenStage
+  use GenStageConsoleWatcher
+
+  def init(counter) do
+    {:producer, counter}
+  end
+
+  def handle_demand(demand, counter) when demand > 0 do
+    # If the counter is 3 and we ask for 2 items, we will
+    # emit the items 3 and 4, and set the state to 5.
+    events = Enum.to_list(counter..counter+demand-1)
+    {:noreply, events, counter + demand}
+  end
+end
+
+defmodule B do
+  use GenStage
+  use GenStageConsoleWatcher
+
+  def init(number) do
+    {:producer_consumer, number}
+  end
+
+  def handle_events(events, _from, number) do
+    # If we receive [0, 1, 2], this will transform
+    # it into [0, 1, 2, 1, 2, 3, 2, 3, 4].
+    events =
+      for event <- events,
+          entry <- event..event+number,
+          do: entry
+    {:noreply, events, number}
+  end
+end
+
+defmodule C do
+  use GenStage
+  use GenStageConsoleWatcher
+
+  def init(:ok) do
+    {:consumer, :the_state_does_not_matter}
+  end
+
+  def handle_events(events, _from, state) do
+    # Wait for a second.
+    :timer.sleep(1000)
+
+    # Inspect the events.
+    #IO.inspect(events)
+
+    # We are a consumer, so we would never emit items.
+    {:noreply, [], state}
+  end
+end
+# :debugger.start()
+# :int.ni(GenStage)
+# :int.break(GenStage, 2163)
+
+{:ok, a} = GenStage.start_link(A, 0)   # starting from zero
+{:ok, b} = GenStage.start_link(B, 2)   # expand by 2
+{:ok, c} = GenStage.start_link(C, :ok) # state does not matter
+
+GenStage.sync_subscribe(b, to: a)
+GenStage.sync_subscribe(c, to: a)
+#Process.sleep(:infinity)

--- a/lib/gen_stage.ex
+++ b/lib/gen_stage.ex
@@ -1,4 +1,5 @@
 defmodule GenStage do
+  require IEx;
   @moduledoc ~S"""
   Stages are computation steps that send and/or receive data
   from other stages.
@@ -929,7 +930,12 @@ defmodule GenStage do
   @callback format_status(:normal | :terminate, [pdict :: {term, term} | state :: term, ...]) ::
     status :: term
 
-  @optional_callbacks [handle_demand: 2, handle_events: 3, format_status: 2]
+  @doc """
+  """
+  @callback handle_metrics(:handle_demand | :handle_events | :handle_subscribe, metrics :: term, stageinfo ::term) ::
+  {:noreply}
+
+  @optional_callbacks [handle_demand: 2, handle_events: 3, format_status: 2, handle_metrics: 3]
 
   @doc false
   defmacro __using__(_) do
@@ -988,8 +994,14 @@ defmodule GenStage do
         {:ok, state}
       end
 
+      @doc false
+      def handle_metrics(_type, _args, _stageinfo) do
+        {:noreply}
+      end
+
       defoverridable [handle_call: 3, handle_info: 2, handle_subscribe: 4,
-                      handle_cancel: 3, handle_cast: 2, terminate: 2, code_change: 3]
+                      handle_cancel: 3, handle_cast: 2, terminate: 2, code_change: 3,
+                      handle_metrics: 3]
     end
   end
 
@@ -2053,6 +2065,7 @@ defmodule GenStage do
   ## Shared helpers
 
   defp noreply_callback(callback, args, %{mod: mod} = stage) do
+    {:noreply} = apply(mod, :handle_metrics, [callback, args, stage])
     handle_noreply_callback apply(mod, callback, args), stage
   end
 
@@ -2115,6 +2128,7 @@ defmodule GenStage do
   defp producer_subscribe(opts, from, stage) do
     %{mod: mod, state: state, dispatcher_state: dispatcher_state} = stage
 
+    {:noreply} = apply(mod, :handle_metrics, [:handle_subscribe, [:consumer], stage])
     case apply(mod, :handle_subscribe, [:consumer, opts, from, state]) do
       {:automatic, state} ->
         # Call the dispatcher after since it may generate demand and the
@@ -2413,6 +2427,7 @@ defmodule GenStage do
     do: split_events(events, limit, counter + 1, [event | acc])
 
   defp consumer_dispatch([{batch, ask} | batches], from, mod, state, stage, count, _hibernate?) do
+    {:noreply} = apply(mod, :handle_metrics, [:handle_events, [batch, from, state], stage])
     case mod.handle_events(batch, from, state) do
       {:noreply, events, state} when is_list(events) ->
         stage = dispatch_events(events, length(events), stage)
@@ -2472,6 +2487,7 @@ defmodule GenStage do
     %{mod: mod, state: state} = stage
     to = {producer_pid, ref}
 
+    {:noreply} = apply(mod, :handle_metrics, [:handle_subscribe, [:producer], stage])
     case apply(mod, :handle_subscribe, [:producer, opts, to, state]) do
       {:automatic, state} ->
         ask(to, max, [:noconnect])


### PR DESCRIPTION
This is a quick and rough spike on instrumenting GenServer as per [this comment](https://github.com/elixir-lang/gen_stage/issues/48#issuecomment-274168757) on #48.

I think the usability for adding instrumentation modules like `GenStageConsoleWatcher` on `.iex.exs` is good for my specific use case. I made this PR to learn if this is a direction the team is OK with and if I should put more work into this.