### PR TITLE
renamed `examples/dynamic_supervisor.exs` to `examples/consumer_supervisor.exs` to match link in README

### DIFF
--- a/examples/consumer_supervisor.exs
+++ b/examples/consumer_supervisor.exs
@@ -1,4 +1,4 @@
-# Usage: mix run examples/dynamic_supervisor.exs
+# Usage: mix run examples/consumer_supervisor.exs
 #
 # Hit Ctrl+C twice to stop it.
 


### PR DESCRIPTION
Link the README points to `consumer_supervisor.exs` for the example on usage. File in the examples directory was still named `dynamic_supervisor.exs`.