### PR TITLE
Fix spelling of "milliseconds" in inline comments

### DIFF
--- a/examples/rate_limiter.exs
+++ b/examples/rate_limiter.exs
@@ -27,7 +27,7 @@ defmodule RateLimiter do
   end
 
   def handle_subscribe(:producer, opts, from, producers) do
-    # We will only allow max_demand events every 5000 miliseconds
+    # We will only allow max_demand events every 5000 milliseconds
     pending = opts[:max_demand] || 1000
     interval = opts[:interval] || 5000
 

--- a/lib/gen_stage.ex
+++ b/lib/gen_stage.ex
@@ -513,7 +513,7 @@ defmodule GenStage do
         end
 
         def handle_subscribe(:producer, opts, from, producers) do
-          # We will only allow max_demand events every 5000 miliseconds
+          # We will only allow max_demand events every 5000 milliseconds
           pending = opts[:max_demand] || 1000
           interval = opts[:interval] || 5000
 


### PR DESCRIPTION
While reading the GenStage documentation at https://hexdocs.pm/gen_stage/GenStage.html
I noticed a minor spelling error.
"miliseconds" should be "milliseconds".
This PR fixes the 2 cases of that spelling I found in gen_stage.