### PR TITLE
Add max demand option example to supervisor documentation part

### DIFF
--- a/lib/gen_stage.ex
+++ b/lib/gen_stage.ex
@@ -225,6 +225,13 @@ defmodule GenStage do
         {:consumer, :the_state_does_not_matter, subscribe_to: [{B, options}]}
       end
 
+  Also we can change the `c:init/1` callback for B,
+  and provide specified `:max_demand` option to the following:
+
+      def init(number) do
+        {:producer_consumer, number, subscribe_to: [{A, max_demand: 10}]}
+     end
+
   And we will no longer need to call `sync_subscribe/2`.
 
   Another advantage of this approach is that it makes it straight-forward


### PR DESCRIPTION
I was trying to give `:max_demand` option when I initialized `GenStage` through the supervisor tree, and it was not quite obvious that you need to specify this parameter into `subscribe_to: [{A, max_demand: 10}]`,  especially wrapped it to `{}` after few hours of debugging even I thought it was a bug in GenStage method
LINE 2436
` deep consumer_init_subscribe(producers, stage) do` which I thought never pass through this parameters, but it wasn't.

If this detailed example will be here it will save time for people who wants to find a proper replacement for this kind of method:
```
GenStage.sync_subscribe(C, to: B, max_demand: @max_demand)
```
