### PR TITLE
Updating docs about setting `Consumer` to `:manual`, not the `Producer`

### DIFF
--- a/lib/gen_stage.ex
+++ b/lib/gen_stage.ex
@@ -490,7 +490,7 @@ defmodule GenStage do
   is sent upstream, avoiding the default behaviour where demand is
   sent after `c:handle_events/3`. Such can be done by implementing
   the `c:handle_subscribe/4` callback and returning `{:manual, state}`
-  instead of the default `{:automatic, state}`. Once the producer mode
+  instead of the default `{:automatic, state}`. Once the consumer mode
   is set to `:manual`, developers must use `GenStage.ask/3` to send
   demand upstream when necessary.
 


### PR DESCRIPTION
I assume you're setting the `Consumer` to manual and not the `Producer` itself as you could have two different `Consumers` where one is manual and the other one isn't. 

Or did I get it wrong? 