### PR TITLE
Language fixes.

### DIFF
--- a/lib/gen_stage.ex
+++ b/lib/gen_stage.ex
@@ -495,7 +495,7 @@ defmodule GenStage do
   demand upstream when necessary.
 
   Note that `:max_demand` and `:min_demand` must be manually respected when
-  manually asking for demand through `GenStage.ask/3`.
+  asking for demand through `GenStage.ask/3`.
 
   For example, the `ConsumerSupervisor` module processes events
   asynchronously by starting a process for each event and this is achieved by

--- a/lib/gen_stage.ex
+++ b/lib/gen_stage.ex
@@ -1500,10 +1500,9 @@ defmodule GenStage do
       GenStage.stream([{producer, max_demand: 100}])
 
   If the producer process exits, the stream will exit with the same
-  reason. If it is expected that the producer will exit and the stream
-  should just halt when such happens, setting the cancel option to
-  either `:transient` or `:temporary` will avoid the stream for exiting
-  as described in the `sync_subscribe/3` docs:
+  reason. If you want the stream to halt instead, set the cancel option
+  to either `:transient` or `:temporary` as described in the
+  `sync_subscribe/3` docs:
 
       GenStage.stream([{producer, max_demand: 100, cancel: :transient}])
 

--- a/lib/gen_stage.ex
+++ b/lib/gen_stage.ex
@@ -367,7 +367,7 @@ defmodule GenStage do
   To handle such cases, we will use a two-element tuple as the broadcaster state
   where the first element is a queue and the second element is the pending
   demand.  When events arrive and there are no consumers, we will store the
-  event in the queue alongside information about the process that broadcasted
+  event in the queue alongside information about the process that broadcast
   the event. When consumers send demand and there are not enough events, we will
   increase the pending demand.  Once we have both data and demand, we
   acknowledge the process that has sent the event to the broadcaster and finally
@@ -457,7 +457,7 @@ defmodule GenStage do
 
   At this point, all consumers must have sent their demand which we were not
   able to fulfill. Now by calling `QueueBroadcaster.sync_notify/1`, the event
-  shall be broadcasted to all consumers at once as we have buffered the demand
+  shall be broadcast to all consumers at once as we have buffered the demand
   in the producer:
 
       QueueBroadcaster.sync_notify(:hello_world)

--- a/lib/gen_stage.ex
+++ b/lib/gen_stage.ex
@@ -1514,7 +1514,7 @@ defmodule GenStage do
   enumerating the stream to subscribe and receive messages
   from producers. However it guarantees it won't remove or
   leave unwanted messages in the mailbox after enumeration
-  except if one of the producers come from a remote node.
+  unless one of the producers comes from a remote node.
   For more information, read the "Known limitations" section
   below.
 

--- a/lib/gen_stage.ex
+++ b/lib/gen_stage.ex
@@ -494,7 +494,7 @@ defmodule GenStage do
   is set to `:manual`, developers must use `GenStage.ask/3` to send
   demand upstream when necessary.
 
-  Note that when `:max_demand` and `:min_demand` must be manually respected when
+  Note that `:max_demand` and `:min_demand` must be manually respected when
   manually asking for demand through `GenStage.ask/3`.
 
   For example, the `ConsumerSupervisor` module processes events

--- a/lib/gen_stage.ex
+++ b/lib/gen_stage.ex
@@ -1179,8 +1179,8 @@ defmodule GenStage do
   guarantee a subscription has effectively been established.
 
   This function will return `{:ok, subscription_tag}` as long as the
-  subscription message is sent. It may return `{:error, :not_a_consumer}` in
-  case the stage is not a consumer. `subscription_tag` is the second element
+  subscription message is sent. It will return `{:error, :not_a_consumer}`
+  when the stage is not a consumer. `subscription_tag` is the second element
   of the two-element tuple that will be passed to `c:handle_subscribe/4`.
 
   ## Options

--- a/lib/gen_stage/broadcast_dispatcher.ex
+++ b/lib/gen_stage/broadcast_dispatcher.ex
@@ -14,7 +14,7 @@ defmodule GenStage.BroadcastDispatcher do
         to: producer,
         selector: fn %{key: key} -> String.starts_with?(key, "foo-") end)
 
-  `consumer` will receive only the events broadcasted from `producer`
+  `consumer` will receive only the events broadcast from `producer`
   for which the selector function returns a truthy value.
 
   The `:selector` option can be specified in sync and async subscriptions,


### PR DESCRIPTION
A few fixes for language tense, typos, etc.

"broadcasted" sounds weird as past tense for "broadcast". It's not nearly as common.

https://english.stackexchange.com/questions/33207/broadcast-or-broadcasted