### PR TITLE
Mark GenStage.child_spec/1 overridable

### DIFF
--- a/lib/gen_stage.ex
+++ b/lib/gen_stage.ex
@@ -1091,7 +1091,8 @@ defmodule GenStage do
       end
 
       defoverridable [handle_call: 3, handle_info: 2, handle_subscribe: 4,
-                      handle_cancel: 3, handle_cast: 2, terminate: 2, code_change: 3]
+                      handle_cancel: 3, handle_cast: 2, terminate: 2, code_change: 3,
+                      child_spec: 1]
     end
   end
 


### PR DESCRIPTION
GenStage.__using__.child_spec/1 is currently not overridable. This makes it impossible to override the default.

This PR handles it like `GenServer` does.