### PR TITLE
TravisCI Test with newer Elixir & OTP Versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ notifications:
   recipients:
     - jose.valim@plataformatec.com.br
 otp_release:
-  - 18.3
+  - 18.0
   - 19.3
   - 20.0
 after_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,20 @@
 language: elixir
 elixir:
-  - 1.3.0
+  - 1.3.4
+  - 1.4.5
+  - 1.5.1
 sudo: false # to use faster container based build environment
 notifications:
   recipients:
     - jose.valim@plataformatec.com.br
 otp_release:
-  - 18.0
+  - 18.3
+  - 19.3
+  - 20.0
 after_script:
   - mix deps.get --only docs
   - MIX_ENV=docs mix inch.report
+matrix:
+  exclude:
+    - elixir: 1.3.4
+      otp_release: 20.0


### PR DESCRIPTION
## Tested Elixir Versions (Newest Minor Version of supported Major Versions):

* `1.3.4`
* `1.4.5`
* `1.5.1`

## Tested OTP Versions (Newest Minor Version of supported Major Versions):
* `18.3`
* `19.3`
* `20.0`

## Excluded

* OTP `20.0` on Elixir `1.3.4`