### PR TITLE
Docs cleanup

### DIFF
--- a/lib/gen_stage.ex
+++ b/lib/gen_stage.ex
@@ -226,7 +226,7 @@ defmodule GenStage do
 
       def init(number) do
         {:producer_consumer, number, subscribe_to: [{A, max_demand: 10}]}
-     end
+      end
 
   And we will no longer need to call `sync_subscribe/2`.
 

--- a/lib/gen_stage/broadcast_dispatcher.ex
+++ b/lib/gen_stage/broadcast_dispatcher.ex
@@ -23,7 +23,7 @@ defmodule GenStage.BroadcastDispatcher do
 
       def init(:ok) do
         {:consumer, :ok, subscribe_to:
-          [{producer, selector: fn %{key: key} -> String.starts_with?(key, "foo-") end}]}`
+          [{producer, selector: fn %{key: key} -> String.starts_with?(key, "foo-") end}]}
       end
 
   """


### PR DESCRIPTION
This PR performs tiny docs cleanup:

* misaligned `end` was messing with generated documentation
* there was one unmatched back tick