### PR TITLE
Specify 0.12 in the installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ GenStage requires Elixir v1.3. Just add `:gen_stage` to your list of dependencie
 
 ```elixir
 def deps do
-  [{:gen_stage, "~> 0.11"}]
+  [{:gen_stage, "~> 0.12"}]
 end
 ```
 


### PR DESCRIPTION
Make sure users get the latest version.