### PR TITLE
Documentation example didn't work out of the box with `Supervisor.child_spec/2`.

### DIFF
--- a/lib/consumer_supervisor.ex
+++ b/lib/consumer_supervisor.ex
@@ -51,7 +51,8 @@ defmodule ConsumerSupervisor do
   Then in the `Printer` module:
 
       defmodule Printer do
-
+        use Task
+        
         def start_link([], event) do
           Task.start_link(fn ->
             IO.inspect({self(), event})

--- a/lib/consumer_supervisor.ex
+++ b/lib/consumer_supervisor.ex
@@ -31,23 +31,33 @@ defmodule ConsumerSupervisor do
   the child, effectively calling `Printer.start_link([], event)`.
 
       defmodule Consumer do
-        def start_link() do
-          children = [Printer]
-          opts = [strategy: :one_for_one, subscribe_to: [{Producer, max_demand: 50}]]
-          ConsumerSupervisor.start_link(children, opts)
+        use ConsumerSupervisor
+
+        def start_link(arg) do
+          ConsumerSupervisor.start_link(__MODULE__, :ok)
         end
+
+        def init(:ok) do
+          children = [
+            worker(Printer, [], restart: :temporary)
+          ]
+    
+          {:ok, children, strategy: :one_for_one, subscribe_to: [{:Producer, max_demand: 50}]}
+      end
+
+
       end
 
   Then in the `Printer` module:
 
       defmodule Printer do
-        use Task
 
         def start_link([], event) do
           Task.start_link(fn ->
             IO.inspect({self(), event})
           end)
         end
+
       end
 
   Similar to `Supervisor`, `ConsumerSupervisor` also provides `start_link/3`,


### PR DESCRIPTION
I'm a bit confused myself over the differences myself actually, but the code sample didn't work out of the box with new child spec syntax and I rather make sure that gets used (as I like it better) 

Maybe you can shed some light over why `init/1`, `use ConsumerSupervisor` wasn't used and `use task` was? 