### PR TITLE
Removing :max_dynamic as it doesn't seem used.

### DIFF
--- a/lib/consumer_supervisor.ex
+++ b/lib/consumer_supervisor.ex
@@ -68,7 +68,6 @@ defmodule ConsumerSupervisor do
                   {:strategy, Supervisor.Spec.strategy} |
                   {:max_restarts, non_neg_integer} |
                   {:max_seconds, non_neg_integer} |
-                  {:max_dynamic, non_neg_integer | :infinity} |
                   {:subscribe_to, [GenStage.stage | {GenStage.stage, keyword()}]}
 
   @doc """


### PR DESCRIPTION
Forgot from https://github.com/elixir-lang/gen_stage/issues/147 ? 

Is this related to new features in Elixir 1.5 regarding DynamicSupervisors? 