### PR TITLE
Add types for the options passed to `init/*`

### DIFF
--- a/lib/gen_stage.ex
+++ b/lib/gen_stage.ex
@@ -718,7 +718,7 @@ defmodule GenStage do
   @typedoc "The supported stage types."
   @type type :: :producer | :consumer | :producer_consumer
 
-  @typedoc "Options used by the `sync_subscribe/` functions"
+  @typedoc "Options used by the `subscribe*` functions"
   @type subscription_options :: keyword
     
   @typedoc "Option values used by the `init*` functions when stage type is `:producer_consumer`"

--- a/lib/gen_stage.ex
+++ b/lib/gen_stage.ex
@@ -718,8 +718,12 @@ defmodule GenStage do
   @typedoc "The supported stage types."
   @type type :: :producer | :consumer | :producer_consumer
 
-  @typedoc "The supported init options."
-  @type options :: keyword()
+ @typedoc "Option values used by the `init*` functions"
+  @type option :: {:max_demand, 1..non_neg_integer} |
+                  {:min_demand, non_neg_integer}
+
+  @typedoc "Options used by the `init*` functions"
+  @type options :: [option]
 
   @typedoc "The stage."
   @type stage :: pid | atom | {:global, term} | {:via, module, term} | {atom, node}

--- a/lib/gen_stage.ex
+++ b/lib/gen_stage.ex
@@ -722,7 +722,7 @@ defmodule GenStage do
   @type subscription_options :: keyword
     
   @typedoc "Option values used by the `init*` functions when stage type is `:producer_consumer`"
-  @type producer_consumer_option :: {:buffer_size, non_neg_integer} |
+  @type producer_consumer_option :: {:buffer_size, non_neg_integer | :infinity} |
                            {:buffer_keep, :first | :last} |
                            {:dispatcher, module | {module, GenStage.Dispatcher.options}}
 

--- a/lib/gen_stage.ex
+++ b/lib/gen_stage.ex
@@ -719,7 +719,7 @@ defmodule GenStage do
   @type type :: :producer | :consumer | :producer_consumer
 
  @typedoc "Option values used by the `init*` functions"
-  @type option :: {:max_demand, 1..non_neg_integer} |
+  @type option :: {:max_demand, non_neg_integer} |
                   {:min_demand, non_neg_integer}
 
   @typedoc "Options used by the `init*` functions"

--- a/lib/gen_stage.ex
+++ b/lib/gen_stage.ex
@@ -718,12 +718,20 @@ defmodule GenStage do
   @typedoc "The supported stage types."
   @type type :: :producer | :consumer | :producer_consumer
 
- @typedoc "Option values used by the `init*` functions"
-  @type option :: {:max_demand, non_neg_integer} |
-                  {:min_demand, non_neg_integer}
+  @typedoc "Options used by the `sync_subscribe/` functions"
+  @type subscription_options :: keyword
+    
+  @typedoc "Option values used by the `init*` functions when stage type is `:producer_consumer`"
+  @type producer_consumer_option :: {:buffer_size, non_neg_integer} |
+                           {:buffer_keep, :first | :last} |
+                           {:dispatcher, module | {module, GenStage.Dispatcher.options}}
 
-  @typedoc "Options used by the `init*` functions"
-  @type options :: [option]
+  @typedoc "Option values used by the `init*` functions when stage type is `:producer`"
+  @type producer_option :: {:demand, :forward | :accumulate} | producer_consumer_option
+  
+  @typedoc "Option values used by the `init*` functions when stage type is `:consumer`"
+  @type consumer_option :: {:subscribe_to, [module | {module, subscription_options}]} | producer_consumer_option
+
 
   @typedoc "The stage."
   @type stage :: pid | atom | {:global, term} | {:via, module, term} | {atom, node}
@@ -810,11 +818,25 @@ defmodule GenStage do
       and the subscription options (as defined in `sync_subscribe/2`).
 
   """
+
   @callback init(args :: term) ::
-    {type, state} |
-    {type, state, options} |
-    :ignore |
-    {:stop, reason :: any} when state: any
+  {type, state} |
+  {type, state, [producer_option]} |
+  :ignore |
+  {:stop, reason :: any} when state: any, type: :producer
+
+  @callback init(args :: term) ::
+  {type, state} |
+  {type, state, [producer_consumer_option]} |
+  :ignore |
+  {:stop, reason :: any} when state: any, type: :producer_consumer
+
+  @callback init(args :: term) ::
+  {type, state} |
+  {type, state, [consumer_option]} |
+  :ignore |
+  {:stop, reason :: any} when state: any, type: :consumer
+
 
   @doc """
   Invoked on `:producer` stages.
@@ -886,7 +908,7 @@ defmodule GenStage do
       end
 
   """
-  @callback handle_subscribe(producer_or_consumer :: :producer | :consumer, options, from, state :: term) ::
+  @callback handle_subscribe(producer_or_consumer :: :producer | :consumer, subscription_options, from, state :: term) ::
     {:automatic | :manual, new_state} |
     {:stop, reason, new_state} when new_state: term, reason: term
 
@@ -1204,7 +1226,7 @@ defmodule GenStage do
         selector: fn %{key: key} -> String.starts_with?(key, "foo-") end)
 
   """
-  @spec sync_subscribe(stage, options, timeout) ::
+  @spec sync_subscribe(stage, subscription_options, timeout) ::
         {:ok, subscription_tag} | {:error, :not_a_consumer} | {:error, {:bad_opts, String.t}}
   def sync_subscribe(stage, opts, timeout \\ 5_000) do
     sync_subscribe(stage, nil, opts, timeout)
@@ -1217,7 +1239,7 @@ defmodule GenStage do
 
   See `sync_subscribe/3` for examples and options.
   """
-  @spec sync_resubscribe(stage, subscription_tag, term, options, timeout) ::
+  @spec sync_resubscribe(stage, subscription_tag, term, subscription_options, timeout) ::
         {:ok, subscription_tag} | {:error, :not_a_consumer} | {:error, {:bad_opts, String.t}}
   def sync_resubscribe(stage, subscription_tag, reason, opts, timeout \\ 5000) do
     sync_subscribe(stage, {subscription_tag, reason}, opts, timeout)
@@ -1242,7 +1264,7 @@ defmodule GenStage do
 
   This function accepts the same options as `sync_subscribe/4`.
   """
-  @spec async_subscribe(stage, options) :: :ok
+  @spec async_subscribe(stage, subscription_options) :: :ok
   def async_subscribe(stage, opts) do
     async_subscribe(stage, nil, opts)
   end
@@ -1253,7 +1275,7 @@ defmodule GenStage do
 
   See `async_subscribe/2` for examples and options.
   """
-  @spec async_resubscribe(stage, subscription_tag, reason :: term, options) :: :ok
+  @spec async_resubscribe(stage, subscription_tag, reason :: term, subscription_options) :: :ok
   def async_resubscribe(stage, subscription_tag, reason, opts) do
     async_subscribe(stage, {subscription_tag, reason}, opts)
   end

--- a/lib/gen_stage/dispatcher.ex
+++ b/lib/gen_stage/dispatcher.ex
@@ -29,10 +29,13 @@ defmodule GenStage.Dispatcher do
 
   """
 
+ @typedoc "Options used by the `init*` functions"
+ @type options :: keyword
+    
   @doc """
   Called on initialization with the options given on `c:GenStage.init/1`.
   """
-  @callback init(opts :: keyword()) :: {:ok, state} when state: any
+  @callback init(opts :: options) :: {:ok, state} when state: any
 
   @doc """
   Called every time the producer gets a new subscriber.

--- a/lib/gen_stage/dispatcher.ex
+++ b/lib/gen_stage/dispatcher.ex
@@ -29,7 +29,7 @@ defmodule GenStage.Dispatcher do
 
   """
 
- @typedoc "Options used by the `init*` functions"
+ @typedoc "Options used by `init/1`"
  @type options :: keyword
     
   @doc """


### PR DESCRIPTION
* Split options for `:producer`, `:producer_consumer` & `:consumer` and overload specification for `init/1` based on `:type`
* Defined keyword option type for `subscription*` functions, might fill in later.
* Defined keyword option type for `Genstage.Dispatcher.init/1` callback, might fill in later.
