### PR TITLE
add 2-arity spec for ConsumerSupervisor.start_link/3

### DIFF
--- a/lib/consumer_supervisor.ex
+++ b/lib/consumer_supervisor.ex
@@ -191,7 +191,8 @@ defmodule ConsumerSupervisor do
   name. The supported values are described under the "Name Registration"
   section in the `GenServer` module docs.
   """
-  @spec start_link(module, any, [option]) :: Supervisor.on_start()
+  @spec start_link(module, any) :: Supervisor.on_start
+  @spec start_link(module, any, [option]) :: Supervisor.on_start
   def start_link(mod, args, opts \\ []) do
     GenStage.start_link(__MODULE__, {mod, args, opts[:name]}, opts)
   end


### PR DESCRIPTION
Fix for #203.

Dialyzer would emit warnings when attempting to the take advantage of the default parameter in `start_link/3`, incorrectly comparing it to the only 2-arity spec. This adds another, more appropriate spec.