### PR TITLE
Enforce the :hash option for non-int partitions in PartitionDispatcher

### DIFF
--- a/lib/gen_stage/partition_dispatcher.ex
+++ b/lib/gen_stage/partition_dispatcher.ex
@@ -75,10 +75,18 @@ defmodule GenStage.PartitionDispatcher do
           partitions
       end
 
+    hash_present? = Keyword.has_key?(opts, :hash)
+
     partitions =
-      for i <- partitions, into: %{} do
-        Process.put(i, [])
-        {i, @init}
+      for partition <- partitions, into: %{} do
+        if not hash_present? and not is_integer(partition) do
+          raise ArgumentError,
+                "when :partitions contains partitions that are not integers, you have to pass " <>
+                  "in the :hash option as well"
+        end
+
+        Process.put(partition, [])
+        {partition, @init}
       end
 
     size = map_size(partitions)

--- a/test/gen_stage/partition_dispatcher_test.exs
+++ b/test/gen_stage/partition_dispatcher_test.exs
@@ -212,6 +212,10 @@ defmodule GenStage.PartitionDispatcherTest do
     assert_raise ArgumentError, ~r/the enumerable of :partitions is required/, fn ->
       dispatcher([])
     end
+
+    assert_raise ArgumentError, ~r/when :partitions contains partitions/, fn ->
+      dispatcher(partitions: [:even, :odd])
+    end
   end
 
   test "errors on subscribe" do


### PR DESCRIPTION
This is not perfect since you can still trick it by doing `partitions: [0, 2]` (integers but not consecutive) but I think it's a good enough compromise.