### PR TITLE
Added missing code changes on GenStage documentation #210

### DIFF
--- a/lib/gen_stage.ex
+++ b/lib/gen_stage.ex
@@ -241,7 +241,25 @@ defmodule GenStage do
       GenStage.start_link(C, :ok)
       GenStage.start_link(C, :ok)
 
-  In a supervision tree, this is often done by starting multiple workers:
+  In a supervision tree, this is often done by starting multiple workers. But to add
+  modules `A` and `B` as workers we have to update first the `c:start_link/1`
+  call to the following for module `A`:
+
+      def start_link(number) do
+        # Calling the stage in module A as A
+        GenStage.start_link(A, number, name: A)
+      end
+
+  And the same for module `B`:
+
+      def start_link(number) do
+        # Calling the stage in module B as B
+        GenStage.start_link(B, number, name: B)
+      end
+
+  Module `C` does not need to be updated because it won't be subscribed to.
+
+  Then we can define our supervision tree like this:
 
       children = [
         worker(A, [0]),

--- a/lib/gen_stage.ex
+++ b/lib/gen_stage.ex
@@ -241,24 +241,20 @@ defmodule GenStage do
       GenStage.start_link(C, :ok)
       GenStage.start_link(C, :ok)
 
-  In a supervision tree, this is often done by starting multiple workers. But to add
-  modules `A` and `B` as workers we have to update first the `c:start_link/1`
-  call to the following for module `A`:
+  In a supervision tree, this is often done by starting multiple workers. Typically
+  we update each `c:start_link/1` call to start a named process:
 
       def start_link(number) do
-        # Calling the stage in module A as A
         GenStage.start_link(A, number, name: A)
       end
 
   And the same for module `B`:
 
       def start_link(number) do
-        # Calling the stage in module B as B
         GenStage.start_link(B, number, name: B)
       end
 
   Module `C` does not need to be updated because it won't be subscribed to.
-
   Then we can define our supervision tree like this:
 
       children = [
@@ -272,9 +268,9 @@ defmodule GenStage do
 
       Supervisor.start_link(children, strategy: :rest_for_one)
 
-  Having multiple consumers is often the easiest and simplest way to
-  leverage concurrency in a GenStage pipeline, especially if events can
-  be processed out of order.
+  Having multiple consumers is often the easiest and simplest way to leverage
+  concurrency in a GenStage pipeline, especially if events can be processed out
+  of order.
 
   Also note that we set the supervision strategy to `:rest_for_one`. This
   is important because if the producer A terminates, all of the other


### PR DESCRIPTION
Pull request for #210 
Without these code changes I receive the error
```
** (Mix) Could not start application testdep: Application.start(:normal, []) returned an error: shutdown: failed to start child: B
    ** (EXIT) no process: the process is not alive or there's no process currently associated with the given name, possibly because its application isn't started

```
After applying the code changes on start_link/1 the application starts correctly and starts counting:

```
iex(1)> [0, 2, 4, 6, 8]
[10, 12, 14, 16, 18]
[20, 22, 24, 26, 28]
[30, 32, 34, 36, 38]
```

I didnt suggest to add the named module on consumer GenStage.start_link(C, :ok) because nobody is going to subscribe to the consumer but maybe is a good practice to always name the process, I am not sure about that.