### PR TITLE
[WIP] Allow dispatcher to buffer demand and resume later

### DIFF
--- a/lib/gen_stage/dispatcher.ex
+++ b/lib/gen_stage/dispatcher.ex
@@ -103,6 +103,11 @@ defmodule GenStage.Dispatcher do
   In case the dispatcher is doing buffering, the message must
   only be sent after all currently buffered consumer messages are
   delivered.
+
+  The returned demand from the dispatcher in this callback ought to be
+  positive only if it was previously requested in `ask/3` and buffered.
   """
-  @callback info(msg :: term, state :: term) :: {:ok, new_state} when new_state: term
+  @callback info(msg :: term, state :: term) ::
+              {:ok, demand :: non_neg_integer, new_state}
+            when new_state: term
 end

--- a/lib/gen_stage/dispatchers/broadcast_dispatcher.ex
+++ b/lib/gen_stage/dispatchers/broadcast_dispatcher.ex
@@ -38,7 +38,7 @@ defmodule GenStage.BroadcastDispatcher do
   @doc false
   def info(msg, state) do
     send(self(), msg)
-    {:ok, state}
+    {:ok, 0, state}
   end
 
   @doc false

--- a/lib/gen_stage/dispatchers/demand_dispatcher.ex
+++ b/lib/gen_stage/dispatchers/demand_dispatcher.ex
@@ -17,7 +17,7 @@ defmodule GenStage.DemandDispatcher do
   @doc false
   def info(msg, state) do
     send(self(), msg)
-    {:ok, state}
+    {:ok, 0, state}
   end
 
   @doc false

--- a/lib/gen_stage/dispatchers/partition_dispatcher.ex
+++ b/lib/gen_stage/dispatchers/partition_dispatcher.ex
@@ -123,7 +123,7 @@ defmodule GenStage.PartitionDispatcher do
           Map.put(infos, info, {msg, queued})
       end
 
-    {:ok, {tag, hash, waiting, pending, partitions, references, infos}}
+    {:ok, 0, {tag, hash, waiting, pending, partitions, references, infos}}
   end
 
   @doc false

--- a/test/gen_stage/broadcast_dispatcher_test.exs
+++ b/test/gen_stage/broadcast_dispatcher_test.exs
@@ -158,7 +158,7 @@ defmodule GenStage.BroadcastDispatcherTest do
     {:ok, 0, disp} = D.subscribe([], {pid, ref2}, disp)
     {:ok, 0, disp} = D.ask(3, {pid, ref1}, disp)
 
-    {:ok, notify_disp} = D.info(:hello, disp)
+    {:ok, 0, notify_disp} = D.info(:hello, disp)
     assert disp == notify_disp
     assert_received :hello
   end

--- a/test/gen_stage/demand_dispatcher_test.exs
+++ b/test/gen_stage/demand_dispatcher_test.exs
@@ -148,7 +148,7 @@ defmodule GenStage.DemandDispatcherTest do
     {:ok, 0, disp} = D.subscribe([], {pid, ref2}, disp)
     {:ok, 3, disp} = D.ask(3, {pid, ref1}, disp)
 
-    {:ok, notify_disp} = D.info(:hello, disp)
+    {:ok, 0, notify_disp} = D.info(:hello, disp)
     assert disp == notify_disp
     assert_received :hello
   end

--- a/test/gen_stage/partition_dispatcher_test.exs
+++ b/test/gen_stage/partition_dispatcher_test.exs
@@ -148,7 +148,7 @@ defmodule GenStage.PartitionDispatcherTest do
     refute_received {:"$gen_consumer", {_, ^ref0}, _}
 
     # The notification should not count as an event
-    {:ok, disp} = D.info(:hello, disp)
+    {:ok, 0, disp} = D.info(:hello, disp)
     {:ok, 5, disp} = D.cancel({pid0, ref0}, disp)
     assert {5, 0} = waiting_and_pending(disp)
     assert_received :hello
@@ -165,7 +165,7 @@ defmodule GenStage.PartitionDispatcherTest do
     {:ok, 0, disp} = D.subscribe([partition: 1], {pid1, ref1}, disp)
     {:ok, 3, disp} = D.ask(3, {pid1, ref1}, disp)
 
-    {:ok, notify_disp} = D.info(:hello, disp)
+    {:ok, 0, notify_disp} = D.info(:hello, disp)
     assert disp == notify_disp
     assert_received :hello
   end
@@ -188,7 +188,7 @@ defmodule GenStage.PartitionDispatcherTest do
     {:ok, 3, disp} = D.ask(3, {pid1, ref1}, disp)
     {:ok, [], disp} = D.dispatch([1, 2, 5], 3, disp)
 
-    {:ok, disp} = D.info(:hello, disp)
+    {:ok, 0, disp} = D.info(:hello, disp)
     refute_received :hello
 
     {:ok, 5, _} = D.ask(5, {pid0, ref0}, disp)


### PR DESCRIPTION
This adds the ability to return `demand` from dispatcher `info` callback in order to allow demand buffering. This is a ground work required for implementing a rate limiting dispatcher.

The changes made in this PR have one downside - a producer-consumer might end-up with events in the queue, but without any demand (e.g. when the dispatcher buffered all the demand since it was started). In this case it's important to process `info` before other events, because `info` can return demand that was previously buffered.

This of course, breaks one existing test https://github.com/elixir-lang/gen_stage/blob/master/test/gen_stage_test.exs#L781

I suspect this might be undesired because of my incomplete understanding how everything fits together.