### PR TITLE
Make broadcast dispatcher subscribe idempotent

### DIFF
--- a/lib/gen_stage/dispatcher.ex
+++ b/lib/gen_stage/dispatcher.ex
@@ -41,7 +41,7 @@ defmodule GenStage.Dispatcher do
   Called every time the producer gets a new subscriber.
   """
   @callback subscribe(opts :: keyword(), from :: {pid, reference}, state :: term) ::
-              {:ok, demand :: non_neg_integer, new_state}
+              {:ok, demand :: non_neg_integer, new_state} | {:error, term}
             when new_state: term
 
   @doc """

--- a/lib/gen_stage/dispatchers/broadcast_dispatcher.ex
+++ b/lib/gen_stage/dispatchers/broadcast_dispatcher.ex
@@ -47,7 +47,7 @@ defmodule GenStage.BroadcastDispatcher do
   end
 
   @doc false
-  def subscribe(opts, {pid, ref}, state = {demands, waiting, subscribed_processes}) do
+  def subscribe(opts, {pid, ref}, {demands, waiting, subscribed_processes}) do
     selector = validate_selector(opts)
 
     if subscribed?(subscribed_processes, pid) do
@@ -56,7 +56,7 @@ defmodule GenStage.BroadcastDispatcher do
           "This subscription has been discared."
       end)
 
-      {:ok, 0, state}
+      {:error, :already_subscribed}
     else
       subscribed_processes = add_subscriber(subscribed_processes, pid)
       {:ok, 0, {add_demand(-waiting, pid, ref, selector, demands), waiting, subscribed_processes}}

--- a/lib/gen_stage/dispatchers/broadcast_dispatcher.ex
+++ b/lib/gen_stage/dispatchers/broadcast_dispatcher.ex
@@ -33,6 +33,8 @@ defmodule GenStage.BroadcastDispatcher do
 
   @behaviour GenStage.Dispatcher
 
+  require Logger
+
   @doc false
   def init(_opts) do
     {:ok, {[], 0, MapSet.new()}}
@@ -48,6 +50,10 @@ defmodule GenStage.BroadcastDispatcher do
   def subscribe(opts, {pid, ref}, state = {demands, waiting, subscribed_processes}) do
     selector = validate_selector(opts)
     if subscribed?(subscribed_processes, pid) do
+      Logger.error(fn ->
+        "#{inspect(pid)} is already registered with #{inspect(self())}. " <>
+          "This subscription has been discared."
+      end)
       {:ok, 0, state}
     else
       subscribed_processes = add_subscriber(subscribed_processes, pid)

--- a/lib/gen_stage/dispatchers/broadcast_dispatcher.ex
+++ b/lib/gen_stage/dispatchers/broadcast_dispatcher.ex
@@ -49,11 +49,13 @@ defmodule GenStage.BroadcastDispatcher do
   @doc false
   def subscribe(opts, {pid, ref}, state = {demands, waiting, subscribed_processes}) do
     selector = validate_selector(opts)
+
     if subscribed?(subscribed_processes, pid) do
       Logger.error(fn ->
         "#{inspect(pid)} is already registered with #{inspect(self())}. " <>
           "This subscription has been discared."
       end)
+
       {:ok, 0, state}
     else
       subscribed_processes = add_subscriber(subscribed_processes, pid)

--- a/test/gen_stage/broadcast_dispatcher_test.exs
+++ b/test/gen_stage/broadcast_dispatcher_test.exs
@@ -12,155 +12,181 @@ defmodule GenStage.BroadcastDispatcherTest do
     pid = self()
     ref = make_ref()
     disp = dispatcher([])
+    expected_subscribers = MapSet.new([pid])
 
     {:ok, 0, disp} = D.subscribe([], {pid, ref}, disp)
-    assert disp == {[{0, pid, ref, nil}], 0}
+    assert disp == {[{0, pid, ref, nil}], 0, expected_subscribers}
 
     {:ok, 0, disp} = D.cancel({pid, ref}, disp)
-    assert disp == {[], 0}
+    assert disp == {[], 0, MapSet.new()}
   end
 
   test "multiple subscriptions with early demand" do
-    pid = self()
+    pid1 = self()
+    pid2 = spawn(fn -> :ok end)
     ref1 = make_ref()
     ref2 = make_ref()
     disp = dispatcher([])
 
-    {:ok, 0, disp} = D.subscribe([], {pid, ref1}, disp)
-    assert disp == {[{0, pid, ref1, nil}], 0}
+    expected_subscribers = MapSet.new([pid1])
 
-    {:ok, 10, disp} = D.ask(10, {pid, ref1}, disp)
-    assert disp == {[{0, pid, ref1, nil}], 10}
+    {:ok, 0, disp} = D.subscribe([], {pid1, ref1}, disp)
+    assert disp == {[{0, pid1, ref1, nil}], 0, expected_subscribers}
 
-    {:ok, 0, disp} = D.subscribe([], {pid, ref2}, disp)
-    assert disp == {[{-10, pid, ref2, nil}, {0, pid, ref1, nil}], 10}
+    {:ok, 10, disp} = D.ask(10, {pid1, ref1}, disp)
+    assert disp == {[{0, pid1, ref1, nil}], 10, expected_subscribers}
 
-    {:ok, 0, disp} = D.cancel({pid, ref1}, disp)
-    assert disp == {[{-10, pid, ref2, nil}], 10}
+    expected_subscribers = MapSet.put(expected_subscribers, pid2)
 
-    {:ok, 0, disp} = D.ask(10, {pid, ref2}, disp)
-    assert disp == {[{0, pid, ref2, nil}], 10}
+    {:ok, 0, disp} = D.subscribe([], {pid2, ref2}, disp)
+    assert disp == {[{-10, pid2, ref2, nil}, {0, pid1, ref1, nil}], 10, expected_subscribers}
+
+    expected_subscribers = MapSet.delete(expected_subscribers, pid1)
+
+    {:ok, 0, disp} = D.cancel({pid1, ref1}, disp)
+    assert disp == {[{-10, pid2, ref2, nil}], 10, expected_subscribers}
+
+    {:ok, 0, disp} = D.ask(10, {pid2, ref2}, disp)
+    assert disp == {[{0, pid2, ref2, nil}], 10, expected_subscribers}
   end
 
   test "multiple subscriptions with late demand" do
-    pid = self()
+    pid1 = self()
+    pid2 = spawn_forwarder()
     ref1 = make_ref()
     ref2 = make_ref()
     disp = dispatcher([])
 
-    {:ok, 0, disp} = D.subscribe([], {pid, ref1}, disp)
-    assert disp == {[{0, pid, ref1, nil}], 0}
+    expected_subscribers = MapSet.new([pid1])
 
-    {:ok, 0, disp} = D.subscribe([], {pid, ref2}, disp)
-    assert disp == {[{0, pid, ref2, nil}, {0, pid, ref1, nil}], 0}
+    {:ok, 0, disp} = D.subscribe([], {pid1, ref1}, disp)
+    assert disp == {[{0, pid1, ref1, nil}], 0, expected_subscribers}
 
-    {:ok, 0, disp} = D.ask(10, {pid, ref1}, disp)
-    assert disp == {[{10, pid, ref1, nil}, {0, pid, ref2, nil}], 0}
+    expected_subscribers = MapSet.put(expected_subscribers, pid2)
 
-    {:ok, 10, disp} = D.cancel({pid, ref2}, disp)
-    assert disp == {[{0, pid, ref1, nil}], 10}
+    {:ok, 0, disp} = D.subscribe([], {pid2, ref2}, disp)
+    assert disp == {[{0, pid2, ref2, nil}, {0, pid1, ref1, nil}], 0, expected_subscribers}
 
-    {:ok, 10, disp} = D.ask(10, {pid, ref1}, disp)
-    assert disp == {[{0, pid, ref1, nil}], 20}
+    {:ok, 0, disp} = D.ask(10, {pid1, ref1}, disp)
+    assert disp == {[{10, pid1, ref1, nil}, {0, pid2, ref2, nil}], 0, expected_subscribers}
+
+    expected_subscribers = MapSet.delete(expected_subscribers, pid2)
+
+    {:ok, 10, disp} = D.cancel({pid2, ref2}, disp)
+    assert disp == {[{0, pid1, ref1, nil}], 10, expected_subscribers}
+
+    {:ok, 10, disp} = D.ask(10, {pid1, ref1}, disp)
+    assert disp == {[{0, pid1, ref1, nil}], 20, expected_subscribers}
   end
 
   test "subscribes, asks and dispatches to multiple consumers" do
-    pid = self()
+    pid1 = spawn_forwarder()
+    pid2 = spawn_forwarder()
+    pid3 = spawn_forwarder()
     ref1 = make_ref()
     ref2 = make_ref()
     ref3 = make_ref()
     disp = dispatcher([])
 
-    {:ok, 0, disp} = D.subscribe([], {pid, ref1}, disp)
-    {:ok, 0, disp} = D.subscribe([], {pid, ref2}, disp)
+    {:ok, 0, disp} = D.subscribe([], {pid1, ref1}, disp)
+    {:ok, 0, disp} = D.subscribe([], {pid2, ref2}, disp)
 
-    {:ok, 0, disp} = D.ask(3, {pid, ref1}, disp)
-    {:ok, 2, disp} = D.ask(2, {pid, ref2}, disp)
-    assert disp == {[{0, pid, ref2, nil}, {1, pid, ref1, nil}], 2}
+    {:ok, 0, disp} = D.ask(3, {pid1, ref1}, disp)
+    {:ok, 2, disp} = D.ask(2, {pid2, ref2}, disp)
+
+    expected_subscribers = MapSet.new([pid1, pid2])
+
+    assert disp == {[{0, pid2, ref2, nil}, {1, pid1, ref1, nil}], 2, expected_subscribers}
 
     # One batch fits all
     {:ok, [], disp} = D.dispatch([:a, :b], 2, disp)
-    assert disp == {[{0, pid, ref2, nil}, {1, pid, ref1, nil}], 0}
+    assert disp == {[{0, pid2, ref2, nil}, {1, pid1, ref1, nil}], 0, expected_subscribers}
 
-    assert_received {:"$gen_consumer", {_, ^ref1}, [:a, :b]}
-    assert_received {:"$gen_consumer", {_, ^ref2}, [:a, :b]}
+    assert_receive {:"$gen_consumer", {_, ^ref1}, [:a, :b]}
+    assert_receive {:"$gen_consumer", {_, ^ref2}, [:a, :b]}
 
     # A batch with left-over
-    {:ok, 1, disp} = D.ask(2, {pid, ref2}, disp)
+    {:ok, 1, disp} = D.ask(2, {pid2, ref2}, disp)
 
     {:ok, [:d], disp} = D.dispatch([:c, :d], 2, disp)
-    assert disp == {[{1, pid, ref2, nil}, {0, pid, ref1, nil}], 0}
-    assert_received {:"$gen_consumer", {_, ^ref1}, [:c]}
-    assert_received {:"$gen_consumer", {_, ^ref2}, [:c]}
+    assert disp == {[{1, pid2, ref2, nil}, {0, pid1, ref1, nil}], 0, expected_subscribers}
+    assert_receive {:"$gen_consumer", {_, ^ref1}, [:c]}
+    assert_receive {:"$gen_consumer", {_, ^ref2}, [:c]}
 
     # A batch with no demand
 
     {:ok, [:d], disp} = D.dispatch([:d], 1, disp)
-    assert disp == {[{1, pid, ref2, nil}, {0, pid, ref1, nil}], 0}
-    refute_received {:"$gen_consumer", {_, _}, _}
+    assert disp == {[{1, pid2, ref2, nil}, {0, pid1, ref1, nil}], 0, expected_subscribers}
+    refute_receive {:"$gen_consumer", {_, _}, _}
 
     # Add a late subscriber
-    {:ok, 1, disp} = D.ask(1, {pid, ref1}, disp)
-    {:ok, 0, disp} = D.subscribe([], {pid, ref3}, disp)
+    {:ok, 1, disp} = D.ask(1, {pid1, ref1}, disp)
+    {:ok, 0, disp} = D.subscribe([], {pid3, ref3}, disp)
     {:ok, [:e], disp} = D.dispatch([:d, :e], 2, disp)
 
-    assert disp == {[{-1, pid, ref3, nil}, {0, pid, ref1, nil}, {0, pid, ref2, nil}], 0}
-    assert_received {:"$gen_consumer", {_, ^ref1}, [:d]}
-    assert_received {:"$gen_consumer", {_, ^ref2}, [:d]}
-    assert_received {:"$gen_consumer", {_, ^ref3}, [:d]}
+    expected_subscribers = MapSet.put(expected_subscribers, pid3)
+
+    assert disp ==
+      {[{-1, pid3, ref3, nil}, {0, pid1, ref1, nil}, {0, pid2, ref2, nil}], 0, expected_subscribers}
+    assert_receive {:"$gen_consumer", {_, ^ref1}, [:d]}
+    assert_receive {:"$gen_consumer", {_, ^ref2}, [:d]}
+    assert_receive {:"$gen_consumer", {_, ^ref3}, [:d]}
 
     # Even out
-    {:ok, 0, disp} = D.ask(2, {pid, ref1}, disp)
-    {:ok, 0, disp} = D.ask(2, {pid, ref2}, disp)
-    {:ok, 2, disp} = D.ask(3, {pid, ref3}, disp)
+    {:ok, 0, disp} = D.ask(2, {pid1, ref1}, disp)
+    {:ok, 0, disp} = D.ask(2, {pid2, ref2}, disp)
+    {:ok, 2, disp} = D.ask(3, {pid3, ref3}, disp)
     {:ok, [], disp} = D.dispatch([:e, :f], 2, disp)
-    assert disp == {[{0, pid, ref3, nil}, {0, pid, ref2, nil}, {0, pid, ref1, nil}], 0}
+    assert disp ==
+      {[{0, pid3, ref3, nil}, {0, pid2, ref2, nil}, {0, pid1, ref1, nil}], 0, expected_subscribers}
 
-    assert_received {:"$gen_consumer", {_, ^ref1}, [:e, :f]}
-    assert_received {:"$gen_consumer", {_, ^ref2}, [:e, :f]}
-    assert_received {:"$gen_consumer", {_, ^ref3}, [:e, :f]}
+    assert_receive {:"$gen_consumer", {_, ^ref1}, [:e, :f]}
+    assert_receive {:"$gen_consumer", {_, ^ref2}, [:e, :f]}
+    assert_receive {:"$gen_consumer", {_, ^ref3}, [:e, :f]}
   end
 
   test "subscribing with a selector function" do
-    pid = self()
+    pid1 = spawn_forwarder()
+    pid2 = spawn_forwarder()
     ref1 = make_ref()
     ref2 = make_ref()
     disp = dispatcher([])
     selector1 = fn %{key: key} -> String.starts_with?(key, "pre") end
     selector2 = fn %{key: key} -> String.starts_with?(key, "pref") end
 
-    {:ok, 0, disp} = D.subscribe([selector: selector1], {pid, ref1}, disp)
-    {:ok, 0, disp} = D.subscribe([selector: selector2], {pid, ref2}, disp)
-    assert {[{0, ^pid, ^ref2, _selector2}, {0, ^pid, ^ref1, _selector1}], 0} = disp
+    {:ok, 0, disp} = D.subscribe([selector: selector1], {pid1, ref1}, disp)
+    {:ok, 0, disp} = D.subscribe([selector: selector2], {pid2, ref2}, disp)
+    assert {[{0, ^pid2, ^ref2, _selector2}, {0, ^pid1, ^ref1, _selector1}], 0, _} = disp
 
-    {:ok, 0, disp} = D.ask(4, {pid, ref2}, disp)
-    {:ok, 4, disp} = D.ask(4, {pid, ref1}, disp)
+    {:ok, 0, disp} = D.ask(4, {pid2, ref2}, disp)
+    {:ok, 4, disp} = D.ask(4, {pid1, ref1}, disp)
 
     events = [%{key: "pref-1234"}, %{key: "pref-5678"}, %{key: "pre0000"}, %{key: "foo0000"}]
     {:ok, [], _disp} = D.dispatch(events, 4, disp)
 
-    assert_received {:"$gen_producer", {_, ^ref1}, {:ask, 1}}
-    assert_received {:"$gen_producer", {_, ^ref2}, {:ask, 2}}
+    assert_receive {:"$gen_producer", {_, ^ref1}, {:ask, 1}}
+    assert_receive {:"$gen_producer", {_, ^ref2}, {:ask, 2}}
 
-    assert_received {:"$gen_consumer", {_, ^ref1},
+    assert_receive {:"$gen_consumer", {_, ^ref1},
                      [%{key: "pref-1234"}, %{key: "pref-5678"}, %{key: "pre0000"}]}
 
-    assert_received {:"$gen_consumer", {_, ^ref2}, [%{key: "pref-1234"}, %{key: "pref-5678"}]}
+    assert_receive {:"$gen_consumer", {_, ^ref2}, [%{key: "pref-1234"}, %{key: "pref-5678"}]}
   end
 
   test "delivers info to current process" do
-    pid = self()
+    pid1 = spawn_forwarder()
+    pid2 = spawn_forwarder()
     ref1 = make_ref()
     ref2 = make_ref()
     disp = dispatcher([])
 
-    {:ok, 0, disp} = D.subscribe([], {pid, ref1}, disp)
-    {:ok, 0, disp} = D.subscribe([], {pid, ref2}, disp)
-    {:ok, 0, disp} = D.ask(3, {pid, ref1}, disp)
+    {:ok, 0, disp} = D.subscribe([], {pid1, ref1}, disp)
+    {:ok, 0, disp} = D.subscribe([], {pid2, ref2}, disp)
+    {:ok, 0, disp} = D.ask(3, {pid1, ref1}, disp)
 
     {:ok, notify_disp} = D.info(:hello, disp)
     assert disp == notify_disp
-    assert_received :hello
+    assert_receive :hello
   end
 
   test "subscribing is idempotent" do
@@ -173,5 +199,19 @@ defmodule GenStage.BroadcastDispatcherTest do
     {:ok, 0, disp} = D.subscribe([], {pid, ref1}, disp)
     {:ok, 0, disp} = D.subscribe([], {pid, ref2}, disp)
     assert disp == {[{0, pid, ref1, nil}], 0, expected_subscribers}
+  end
+
+  defp spawn_forwarder do
+    parent = self()
+
+    spawn_link(fn -> forwarder_loop(parent) end)
+  end
+
+  defp forwarder_loop(parent) do
+    receive do
+      msg ->
+        send(parent, msg)
+        forwarder_loop(parent)
+    end
   end
 end

--- a/test/gen_stage/broadcast_dispatcher_test.exs
+++ b/test/gen_stage/broadcast_dispatcher_test.exs
@@ -4,7 +4,7 @@ defmodule GenStage.BroadcastDispatcherTest do
   alias GenStage.BroadcastDispatcher, as: D
 
   defp dispatcher(opts) do
-    {:ok, {[], 0} = state} = D.init(opts)
+    {:ok, {[], 0, _subscribers} = state} = D.init(opts)
     state
   end
 
@@ -168,9 +168,10 @@ defmodule GenStage.BroadcastDispatcherTest do
     ref1 = make_ref()
     ref2 = make_ref()
     disp = dispatcher([])
+    expected_subscribers = MapSet.new([pid])
 
     {:ok, 0, disp} = D.subscribe([], {pid, ref1}, disp)
     {:ok, 0, disp} = D.subscribe([], {pid, ref2}, disp)
-    assert disp == {[{0, pid, ref1, nil}], 0}
+    assert disp == {[{0, pid, ref1, nil}], 0, expected_subscribers}
   end
 end

--- a/test/gen_stage/broadcast_dispatcher_test.exs
+++ b/test/gen_stage/broadcast_dispatcher_test.exs
@@ -203,7 +203,7 @@ defmodule GenStage.BroadcastDispatcherTest do
     {:ok, 0, disp} = D.subscribe([], {pid, ref1}, disp)
 
     assert ExUnit.CaptureLog.capture_log(fn ->
-             {:ok, 0, disp} = D.subscribe([], {pid, ref2}, disp)
+             assert {:error, _} = D.subscribe([], {pid, ref2}, disp)
              assert disp == {[{0, pid, ref1, nil}], 0, expected_subscribers}
            end) =~ "already registered"
   end

--- a/test/gen_stage/broadcast_dispatcher_test.exs
+++ b/test/gen_stage/broadcast_dispatcher_test.exs
@@ -127,7 +127,9 @@ defmodule GenStage.BroadcastDispatcherTest do
     expected_subscribers = MapSet.put(expected_subscribers, pid3)
 
     assert disp ==
-      {[{-1, pid3, ref3, nil}, {0, pid1, ref1, nil}, {0, pid2, ref2, nil}], 0, expected_subscribers}
+             {[{-1, pid3, ref3, nil}, {0, pid1, ref1, nil}, {0, pid2, ref2, nil}], 0,
+              expected_subscribers}
+
     assert_receive {:"$gen_consumer", {_, ^ref1}, [:d]}
     assert_receive {:"$gen_consumer", {_, ^ref2}, [:d]}
     assert_receive {:"$gen_consumer", {_, ^ref3}, [:d]}
@@ -137,8 +139,10 @@ defmodule GenStage.BroadcastDispatcherTest do
     {:ok, 0, disp} = D.ask(2, {pid2, ref2}, disp)
     {:ok, 2, disp} = D.ask(3, {pid3, ref3}, disp)
     {:ok, [], disp} = D.dispatch([:e, :f], 2, disp)
+
     assert disp ==
-      {[{0, pid3, ref3, nil}, {0, pid2, ref2, nil}, {0, pid1, ref1, nil}], 0, expected_subscribers}
+             {[{0, pid3, ref3, nil}, {0, pid2, ref2, nil}, {0, pid1, ref1, nil}], 0,
+              expected_subscribers}
 
     assert_receive {:"$gen_consumer", {_, ^ref1}, [:e, :f]}
     assert_receive {:"$gen_consumer", {_, ^ref2}, [:e, :f]}
@@ -168,7 +172,7 @@ defmodule GenStage.BroadcastDispatcherTest do
     assert_receive {:"$gen_producer", {_, ^ref2}, {:ask, 2}}
 
     assert_receive {:"$gen_consumer", {_, ^ref1},
-                     [%{key: "pref-1234"}, %{key: "pref-5678"}, %{key: "pre0000"}]}
+                    [%{key: "pref-1234"}, %{key: "pref-5678"}, %{key: "pre0000"}]}
 
     assert_receive {:"$gen_consumer", {_, ^ref2}, [%{key: "pref-1234"}, %{key: "pref-5678"}]}
   end
@@ -197,10 +201,11 @@ defmodule GenStage.BroadcastDispatcherTest do
     expected_subscribers = MapSet.new([pid])
 
     {:ok, 0, disp} = D.subscribe([], {pid, ref1}, disp)
+
     assert ExUnit.CaptureLog.capture_log(fn ->
-      {:ok, 0, disp} = D.subscribe([], {pid, ref2}, disp)
-      assert disp == {[{0, pid, ref1, nil}], 0, expected_subscribers}
-    end) =~ "already registered"
+             {:ok, 0, disp} = D.subscribe([], {pid, ref2}, disp)
+             assert disp == {[{0, pid, ref1, nil}], 0, expected_subscribers}
+           end) =~ "already registered"
   end
 
   defp spawn_forwarder do

--- a/test/gen_stage/broadcast_dispatcher_test.exs
+++ b/test/gen_stage/broadcast_dispatcher_test.exs
@@ -162,4 +162,15 @@ defmodule GenStage.BroadcastDispatcherTest do
     assert disp == notify_disp
     assert_received :hello
   end
+
+  test "subscribing is idempotent" do
+    pid = self()
+    ref1 = make_ref()
+    ref2 = make_ref()
+    disp = dispatcher([])
+
+    {:ok, 0, disp} = D.subscribe([], {pid, ref1}, disp)
+    {:ok, 0, disp} = D.subscribe([], {pid, ref2}, disp)
+    assert disp == {[{0, pid, ref1, nil}], 0}
+  end
 end

--- a/test/gen_stage/broadcast_dispatcher_test.exs
+++ b/test/gen_stage/broadcast_dispatcher_test.exs
@@ -197,8 +197,10 @@ defmodule GenStage.BroadcastDispatcherTest do
     expected_subscribers = MapSet.new([pid])
 
     {:ok, 0, disp} = D.subscribe([], {pid, ref1}, disp)
-    {:ok, 0, disp} = D.subscribe([], {pid, ref2}, disp)
-    assert disp == {[{0, pid, ref1, nil}], 0, expected_subscribers}
+    assert ExUnit.CaptureLog.capture_log(fn ->
+      {:ok, 0, disp} = D.subscribe([], {pid, ref2}, disp)
+      assert disp == {[{0, pid, ref1, nil}], 0, expected_subscribers}
+    end) =~ "already registered"
   end
 
   defp spawn_forwarder do

--- a/test/gen_stage_test.exs
+++ b/test/gen_stage_test.exs
@@ -976,8 +976,14 @@ defmodule GenStageTest do
       GenStage.async_subscribe(consumer2, to: producer)
       GenStage.async_subscribe(consumer2, to: producer)
 
+      # Give the async subscribe some time
+      Process.sleep(100)
+
       producer_state = :sys.get_state(producer)
-      assert [{^consumer, _}, {^consumer2, _}] = Map.values(producer_state.consumers)
+
+      assert [consumer, consumer2] |> Enum.sort() ==
+               producer_state.consumers |> Map.values() |> Enum.map(&elem(&1, 0)) |> Enum.sort()
+
       consumer_state = :sys.get_state(consumer2)
       assert [{^producer, _, _}] = Map.values(consumer_state.producers)
     end


### PR DESCRIPTION
This pull request makes subscribing to a `BroadcastDispatcher` idempotent. If a process tries to subscribe more than once, the latter attempts are ignored and an error message is logged.

Fix #224.