### PR TITLE
Fix type for subscription_options

### DIFF
--- a/lib/gen_stage.ex
+++ b/lib/gen_stage.ex
@@ -769,11 +769,14 @@ defmodule GenStage do
   @typedoc "The supported stage types."
   @type type :: :producer | :consumer | :producer_consumer
 
-  @typedoc "Options used by the `subscribe*` functions"
-  @type subscription_options ::
+  @typedoc "Option used by the `subscribe*` functions"
+  @type subscription_option ::
           {:cancel, :permanent | :transient | :temporary}
           | {:min_demand, integer}
           | {:max_demand, integer}
+
+  @typedoc "Options used by the `subscribe*` functions"
+  @type subscription_options :: [subscription_option()]
 
   @typedoc "Option values used by the `init*` specific to `:producer` type"
   @type producer_only_option :: {:demand, :forward | :accumulate}


### PR DESCRIPTION
It seems like the name suggested it was a keyword list, but instead it
defined a single option. This confusion carried on into the spec for
`handle_subscribe` where the typespec defined the `opts` argument as a
tuple instead of a keyword list.

I opted for redefining the existing reference to this type since it
might be used outside as to not introduce any breaking changes. If this
isn't required, I'm open to renaming the existing type to
`subscription_option` and changing the existing spec to be a list of
tuples instead of a single tuple.