### PR TITLE
docs: make documentation clearer

### DIFF
--- a/lib/gen_stage/dispatchers/partition_dispatcher.ex
+++ b/lib/gen_stage/dispatchers/partition_dispatcher.ex
@@ -23,8 +23,8 @@ defmodule GenStage.PartitionDispatcher do
       a tuple with two elements, the event to be dispatched as first argument 
       and the partition as second. The partition must be one of the partitions
       specified in `:partitions` above. The default uses 
-      `fn event -> {event, :erlang.phash2(event, Enum.count(partitions))} end`
-      on the event to select the partition.
+      `fn event, count -> {event, :erlang.phash2(event, count)} end`
+      on the event to select the partition, where count is `Enum.count(partitions)`.
 
   ### Examples
 
@@ -95,8 +95,8 @@ defmodule GenStage.PartitionDispatcher do
     {:ok, {make_ref(), hash, 0, 0, partitions, %{}, %{}}}
   end
 
-  defp hash(event, range) do
-    {event, :erlang.phash2(event, range)}
+  defp hash(event, count) do
+    {event, :erlang.phash2(event, count)}
   end
 
   @doc false


### PR DESCRIPTION
this makes the structure of the hash function more clear in the documentation, should anyone want to substitute their own implementation.  Also in the code for the hash function itself, "range" seems inappropriate since that might imply elixir's range type.