### PR TITLE
[docs] fix typo in state of supervised children

### DIFF
--- a/lib/gen_stage.ex
+++ b/lib/gen_stage.ex
@@ -258,8 +258,8 @@ defmodule GenStage do
   Then we can define our supervision tree like this:
 
       children = [
-        {A, [0]},
-        {B, [2]},
+        {A, 0},
+        {B, 2},
         Supervisor.child_spec({C, []}, id: :c1),
         Supervisor.child_spec({C, []}, id: :c2),
         Supervisor.child_spec({C, []}, id: :c3),


### PR DESCRIPTION
I noticed this typo when following the tutorial in the docs. Without the change in this PR, I get this error:

```
08:32:24.607 [error] GenServer ABC.A terminating
** (ArithmeticError) bad argument in arithmetic expression
    :erlang.+([0], 10)
    (elixirspikes) lib/abc/a.ex:19: ABC.A.handle_demand/2
    (gen_stage) lib/gen_stage.ex:2053: GenStage.noreply_callback/3
    (stdlib) gen_server.erl:637: :gen_server.try_dispatch/4
    (stdlib) gen_server.erl:711: :gen_server.handle_msg/6
    (stdlib) proc_lib.erl:249: :proc_lib.init_p_do_apply/3
Last message: {:"$gen_producer", {#PID<0.210.0>, #Reference<0.2277189294.695468035.90236>}, {:ask, 10}}
State: [0]
```