### PR TITLE
Add :to opt to subscription_option typespec

### DIFF
--- a/lib/gen_stage.ex
+++ b/lib/gen_stage.ex
@@ -772,6 +772,7 @@ defmodule GenStage do
   @typedoc "Option used by the `subscribe*` functions"
   @type subscription_option ::
           {:cancel, :permanent | :transient | :temporary}
+          | {:to, GenServer.server()}
           | {:min_demand, integer}
           | {:max_demand, integer}
 


### PR DESCRIPTION
Wasn't positive if this was completely correct, but this is eventually passed down to `GenServer.whereis/1` so I used its typespec. 

Resolves https://github.com/elixir-lang/gen_stage/issues/246