### PR TITLE
Fix Elixir 1.11 warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,10 @@ jobs:
             warnings_as_errors: true # not 1.10 as its --warnigs-as-errors has bugs https://github.com/elixir-lang/elixir/issues/10073
           - elixir: 1.10.3
             otp: 21.3.8.17
-          - elixir: 1.10.3
-            otp: 23.0.3
+          - elixir: 1.11.1
+            otp: 21.3.8.17
+          - elixir: 1.11.1
+            otp: 23.1.1
             check_formatted: true
     env:
       MIX_ENV: test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - elixir: 1.5.3
-            otp: 19.3.6.13
-          - elixir: 1.6.6
-            otp: 19.3.6.13
           - elixir: 1.7.4
             otp: 19.3.6.13
           - elixir: 1.8.2

--- a/lib/consumer_supervisor.ex
+++ b/lib/consumer_supervisor.ex
@@ -571,7 +571,7 @@ defmodule ConsumerSupervisor do
       apply(m, f, a)
     catch
       kind, reason ->
-        {:error, exit_reason(kind, reason, System.stacktrace())}
+        {:error, exit_reason(kind, reason, __STACKTRACE__)}
     else
       {:ok, pid, extra} when is_pid(pid) -> {:ok, pid, extra}
       {:ok, pid} when is_pid(pid) -> {:ok, pid}

--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,7 @@ defmodule GenStage.Mixfile do
     [
       app: :gen_stage,
       version: @version,
-      elixir: "~> 1.5",
+      elixir: "~> 1.7",
       package: package(),
       description: "Producer and consumer actors with back-pressure for Elixir",
       start_permanent: Mix.env() == :prod,

--- a/test/consumer_supervisor_test.exs
+++ b/test/consumer_supervisor_test.exs
@@ -611,7 +611,7 @@ defmodule ConsumerSupervisorTest do
         try do
           throw(:oops)
         catch
-          :oops -> System.stacktrace()
+          :oops -> __STACKTRACE__
         end
 
       :erlang.raise(class, :oops, stack)


### PR DESCRIPTION
This fixes the `System.stacktrace/0` deprecation warning on Elixir 1.11 and also adds it to the CI matrix. This does remove support for 1.5 and 1.6 though since `__STACKTRACE__` was added in 1.7.