### PR TITLE
fix(ConsumerSupervisor): allow map-style child specs

### DIFF
--- a/lib/consumer_supervisor.ex
+++ b/lib/consumer_supervisor.ex
@@ -166,7 +166,8 @@ defmodule ConsumerSupervisor do
   and will exit not only on crashes but also if the parent process
   exits with `:normal` reason.
   """
-  @spec start_link([Supervisor.Spec.spec()], [option]) :: Supervisor.on_start()
+  @spec start_link([Supervisor.Spec.spec() | Supervisor.child_spec()], [option]) ::
+          Supervisor.on_start()
   def start_link(children, options) when is_list(children) do
     {sup_options, start_options} =
       Keyword.split(options, [:strategy, :max_restarts, :max_seconds, :subscribe_to])


### PR DESCRIPTION
`Supervisor.Spec.spec()` is the older tuple-style child
spec. `ConsumerSupervisor.init/2` support the newer map-style child specs,
but the type did not not reflect that. That resulted in Dialyzer errors like
this:

```
example.ex:8:no_return
Function start_link/1 has no local return.
________________________________________________________________________________
example.ex:24:call
The function call will not succeed.

ConsumerSupervisor.start_link(
  _children :: [
    %{:id => _, :restart => :temporary, :start => {_, :start_link, [Keyword.t(), ...]}},
    ...
  ],
  _supervisor_opts :: [{atom(), _}, ...]
)

breaks the contract
Contract head:
([Supervisor.Spec.spec()], [option()]) :: Supervisor.on_start()

Contract head:
(module(), any()) :: Supervisor.on_start()
```

This updates the spec to show that `start_link/2` can also accept a map.