### PR TITLE
Update docs

### DIFF
--- a/lib/gen_stage.ex
+++ b/lib/gen_stage.ex
@@ -515,10 +515,9 @@ defmodule GenStage do
 
   Both `:producer_consumer` and `:consumer` stages have been designed to do
   their work in the `c:handle_events/3` callback. This means that, after
-  `c:handle_events/3` is invoked, both `:producer_consumer` and `:consumer`
-  stages will immediately send demand upstream and ask for more items, as the
-  stage that produced the events assumes events have been fully processed by
-  `c:handle_events/3`.
+  `c:handle_events/3` has been executed, both `:producer_consumer` and `:consumer`
+  stages will immediately send demand upstream and ask for more items. It is 
+  assumed that events have been fully processed by `c:handle_events/3`.
 
   Such default behaviour makes `:producer_consumer` and `:consumer` stages
   unfeasible for doing asynchronous work. However, given `GenStage` was designed


### PR DESCRIPTION
Make it a little more clear that demand is sent after `handle_events/3` is done and not when starting it.

Also removed the part about "the stage that produced the events assumes". This is not really the case. The producer does not assume anything. It just waits for new demand. It doesn't track which events were processed. At least that's my understanding of it.