### PR TITLE
Add references for license

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,4 +38,5 @@ end
 
 ## License
 
-Same as Elixir.
+Same as Elixir under Apache License 2.0.
+Check [NOTICE](https://github.com/elixir-lang/elixir/blob/main/NOTICE) and [LICENSE](https://github.com/elixir-lang/elixir/blob/main/LICENSE) for more information.

--- a/examples/gen_event.exs
+++ b/examples/gen_event.exs
@@ -2,7 +2,7 @@
 defmodule Broadcaster do
   @moduledoc """
   Using a GenStage for implementing a GenEvent manager
-  replacement where each handler runs as a separate process.
+  replacement, where each handler runs as a separate process.
   It is around 40 LOC without docs and comments.
 
   This implementation will keep events in an internal queue


### PR DESCRIPTION
Add references for license section in README, add missing comma in examples.