### PR TITLE
Account for buffered events in dispatchers

### DIFF
--- a/lib/gen_stage.ex
+++ b/lib/gen_stage.ex
@@ -2040,8 +2040,9 @@ defmodule GenStage do
       when is_integer(counter) do
     case consumers do
       %{^ref => _} ->
-        %{dispatcher_state: dispatcher_state} = stage
-        dispatcher_callback(:ask, [counter, from, dispatcher_state], stage)
+        %{dispatcher_state: dispatcher_state, buffer: buffer} = stage
+        buffer_size = Buffer.estimate_size(buffer)
+        dispatcher_callback(:ask, [counter, buffer_size, from, dispatcher_state], stage)
 
       %{} ->
         msg = {:"$gen_consumer", {self(), ref}, {:cancel, :unknown_subscription}}

--- a/lib/gen_stage/dispatcher.ex
+++ b/lib/gen_stage/dispatcher.ex
@@ -70,7 +70,7 @@ defmodule GenStage.Dispatcher do
   It is guaranteed the reference given in `from` points to a
   reference previously given in subscribe.
   """
-  @callback ask(demand :: pos_integer, from :: {pid, reference}, state :: term) ::
+  @callback ask(demand :: pos_integer, buffer_size :: pos_integer, from :: {pid, reference}, state :: term) ::
               {:ok, actual_demand :: non_neg_integer, new_state}
             when new_state: term
 

--- a/lib/gen_stage/dispatchers/broadcast_dispatcher.ex
+++ b/lib/gen_stage/dispatchers/broadcast_dispatcher.ex
@@ -102,7 +102,7 @@ defmodule GenStage.BroadcastDispatcher do
   end
 
   @doc false
-  def ask(counter, {pid, ref}, {demands, waiting, subscribed_processes}) do
+  def ask(counter, _buffer_size, {pid, ref}, {demands, waiting, subscribed_processes}) do
     {current, selector, demands} = pop_demand(ref, demands)
     demands = add_demand(current + counter, pid, ref, selector, demands)
     new_min = get_min(demands)

--- a/lib/gen_stage/dispatchers/demand_dispatcher.ex
+++ b/lib/gen_stage/dispatchers/demand_dispatcher.ex
@@ -53,7 +53,7 @@ defmodule GenStage.DemandDispatcher do
   end
 
   @doc false
-  def ask(counter, {pid, ref}, {demands, pending, max, shuffle_demand}) do
+  def ask(counter, buffer_size, {pid, ref}, {demands, pending, max, shuffle_demand}) do
     max = max || counter
 
     if counter > max do
@@ -69,7 +69,8 @@ defmodule GenStage.DemandDispatcher do
     demands = add_demand(current + counter, pid, ref, demands)
 
     already_sent = min(pending, counter)
-    {:ok, counter - already_sent, {demands, pending - already_sent, max, shuffle_demand}}
+    buffered = min(already_sent, buffer_size)
+    {:ok, counter - already_sent + buffered, {demands, pending - already_sent, max, shuffle_demand}}
   end
 
   @doc false

--- a/test/gen_stage/broadcast_dispatcher_test.exs
+++ b/test/gen_stage/broadcast_dispatcher_test.exs
@@ -30,7 +30,7 @@ defmodule GenStage.BroadcastDispatcherTest do
     {:ok, 0, disp} = D.subscribe([], {pid, ref}, disp)
     assert disp == {[{0, pid, ref, nil}], 0, expected_subscribers}
 
-    {:ok, 10, disp} = D.ask(10, {pid, ref}, disp)
+    {:ok, 10, disp} = D.ask(10, 0, {pid, ref}, disp)
     assert disp == {[{0, pid, ref, nil}], 10, expected_subscribers}
 
     {:ok, 0, disp} = D.cancel({pid, ref}, disp)
@@ -49,7 +49,7 @@ defmodule GenStage.BroadcastDispatcherTest do
     {:ok, 0, disp} = D.subscribe([], {pid1, ref1}, disp)
     assert disp == {[{0, pid1, ref1, nil}], 0, expected_subscribers}
 
-    {:ok, 10, disp} = D.ask(10, {pid1, ref1}, disp)
+    {:ok, 10, disp} = D.ask(10, 0, {pid1, ref1}, disp)
     assert disp == {[{0, pid1, ref1, nil}], 10, expected_subscribers}
 
     expected_subscribers = MapSet.put(expected_subscribers, pid2)
@@ -62,7 +62,7 @@ defmodule GenStage.BroadcastDispatcherTest do
     {:ok, 0, disp} = D.cancel({pid1, ref1}, disp)
     assert disp == {[{0, pid2, ref2, nil}], 0, expected_subscribers}
 
-    {:ok, 10, disp} = D.ask(10, {pid2, ref2}, disp)
+    {:ok, 10, disp} = D.ask(10, 0, {pid2, ref2}, disp)
     assert disp == {[{0, pid2, ref2, nil}], 10, expected_subscribers}
   end
 
@@ -83,7 +83,7 @@ defmodule GenStage.BroadcastDispatcherTest do
     {:ok, 0, disp} = D.subscribe([], {pid2, ref2}, disp)
     assert disp == {[{0, pid2, ref2, nil}, {0, pid1, ref1, nil}], 0, expected_subscribers}
 
-    {:ok, 0, disp} = D.ask(10, {pid1, ref1}, disp)
+    {:ok, 0, disp} = D.ask(10, 0, {pid1, ref1}, disp)
     assert disp == {[{10, pid1, ref1, nil}, {0, pid2, ref2, nil}], 0, expected_subscribers}
 
     expected_subscribers = MapSet.delete(expected_subscribers, pid2)
@@ -91,7 +91,7 @@ defmodule GenStage.BroadcastDispatcherTest do
     {:ok, 10, disp} = D.cancel({pid2, ref2}, disp)
     assert disp == {[{0, pid1, ref1, nil}], 10, expected_subscribers}
 
-    {:ok, 10, disp} = D.ask(10, {pid1, ref1}, disp)
+    {:ok, 10, disp} = D.ask(10, 0, {pid1, ref1}, disp)
     assert disp == {[{0, pid1, ref1, nil}], 20, expected_subscribers}
   end
 
@@ -107,8 +107,8 @@ defmodule GenStage.BroadcastDispatcherTest do
     {:ok, 0, disp} = D.subscribe([], {pid1, ref1}, disp)
     {:ok, 0, disp} = D.subscribe([], {pid2, ref2}, disp)
 
-    {:ok, 0, disp} = D.ask(3, {pid1, ref1}, disp)
-    {:ok, 2, disp} = D.ask(2, {pid2, ref2}, disp)
+    {:ok, 0, disp} = D.ask(3, 0, {pid1, ref1}, disp)
+    {:ok, 2, disp} = D.ask(2, 0, {pid2, ref2}, disp)
 
     expected_subscribers = MapSet.new([pid1, pid2])
 
@@ -122,7 +122,7 @@ defmodule GenStage.BroadcastDispatcherTest do
     assert_receive {:"$gen_consumer", {_, ^ref2}, [:a, :b]}
 
     # A batch with left-over
-    {:ok, 1, disp} = D.ask(2, {pid2, ref2}, disp)
+    {:ok, 1, disp} = D.ask(2, 0, {pid2, ref2}, disp)
 
     {:ok, [:d], disp} = D.dispatch([:c, :d], 2, disp)
     assert disp == {[{1, pid2, ref2, nil}, {0, pid1, ref1, nil}], 0, expected_subscribers}
@@ -135,7 +135,7 @@ defmodule GenStage.BroadcastDispatcherTest do
     refute_received {:"$gen_consumer", {_, _}, _}
 
     # Add a late subscriber
-    {:ok, 1, disp} = D.ask(1, {pid1, ref1}, disp)
+    {:ok, 1, disp} = D.ask(1, 0, {pid1, ref1}, disp)
     {:ok, 0, disp} = D.subscribe([], {pid3, ref3}, disp)
     {:ok, [:d, :e], disp} = D.dispatch([:d, :e], 2, disp)
 
@@ -146,9 +146,9 @@ defmodule GenStage.BroadcastDispatcherTest do
               expected_subscribers}
 
     # Even out
-    {:ok, 0, disp} = D.ask(2, {pid1, ref1}, disp)
-    {:ok, 0, disp} = D.ask(2, {pid2, ref2}, disp)
-    {:ok, 3, disp} = D.ask(3, {pid3, ref3}, disp)
+    {:ok, 0, disp} = D.ask(2, 0, {pid1, ref1}, disp)
+    {:ok, 0, disp} = D.ask(2, 0, {pid2, ref2}, disp)
+    {:ok, 3, disp} = D.ask(3, 0, {pid3, ref3}, disp)
     {:ok, [], disp} = D.dispatch([:d, :e, :f], 3, disp)
 
     assert disp ==
@@ -173,8 +173,8 @@ defmodule GenStage.BroadcastDispatcherTest do
     {:ok, 0, disp} = D.subscribe([selector: selector2], {pid2, ref2}, disp)
     assert {[{0, ^pid2, ^ref2, _selector2}, {0, ^pid1, ^ref1, _selector1}], 0, _} = disp
 
-    {:ok, 0, disp} = D.ask(4, {pid2, ref2}, disp)
-    {:ok, 4, disp} = D.ask(4, {pid1, ref1}, disp)
+    {:ok, 0, disp} = D.ask(4, 0, {pid2, ref2}, disp)
+    {:ok, 4, disp} = D.ask(4, 0, {pid1, ref1}, disp)
 
     events = [%{key: "pref-1234"}, %{key: "pref-5678"}, %{key: "pre0000"}, %{key: "foo0000"}]
     {:ok, [], _disp} = D.dispatch(events, 4, disp)
@@ -197,7 +197,7 @@ defmodule GenStage.BroadcastDispatcherTest do
 
     {:ok, 0, disp} = D.subscribe([], {pid1, ref1}, disp)
     {:ok, 0, disp} = D.subscribe([], {pid2, ref2}, disp)
-    {:ok, 0, disp} = D.ask(3, {pid1, ref1}, disp)
+    {:ok, 0, disp} = D.ask(3, 0, {pid1, ref1}, disp)
 
     {:ok, notify_disp} = D.info(:hello, disp)
     assert disp == notify_disp

--- a/test/gen_stage/partition_dispatcher_test.exs
+++ b/test/gen_stage/partition_dispatcher_test.exs
@@ -19,14 +19,41 @@ defmodule GenStage.PartitionDispatcherTest do
 
     # Subscribe, ask and cancel and leave some demand
     {:ok, 0, disp} = D.subscribe([partition: 0], {pid, ref}, disp)
-    {:ok, 10, disp} = D.ask(10, {pid, ref}, disp)
+    {:ok, 10, disp} = D.ask(10, 0, {pid, ref}, disp)
     assert {10, 0} = waiting_and_pending(disp)
     {:ok, 0, disp} = D.cancel({pid, ref}, disp)
     assert {10, 10} = waiting_and_pending(disp)
 
     # Subscribe again and the same demand is back
     {:ok, 0, disp} = D.subscribe([partition: 1], {pid, ref}, disp)
-    {:ok, 0, disp} = D.ask(5, {pid, ref}, disp)
+    {:ok, 0, disp} = D.ask(5, 0, {pid, ref}, disp)
+    assert {10, 5} = waiting_and_pending(disp)
+    {:ok, 0, disp} = D.cancel({pid, ref}, disp)
+    assert {10, 10} = waiting_and_pending(disp)
+  end
+
+  test "asks with buffered events" do
+    pid = self()
+    ref = make_ref()
+    disp = dispatcher(partitions: 2)
+
+    # Subscribe, ask and cancel and leave some demand
+    {:ok, 0, disp} = D.subscribe([partition: 0], {pid, ref}, disp)
+    {:ok, 10, disp} = D.ask(10, 0, {pid, ref}, disp)
+    assert {10, 0} = waiting_and_pending(disp)
+    {:ok, 0, disp} = D.cancel({pid, ref}, disp)
+    assert {10, 10} = waiting_and_pending(disp)
+
+    # Subscribe again and ask with a buffer greater than the counter
+    {:ok, 0, disp} = D.subscribe([partition: 1], {pid, ref}, disp)
+    {:ok, 5, disp} = D.ask(5, 7, {pid, ref}, disp)
+    assert {10, 5} = waiting_and_pending(disp)
+    {:ok, 0, disp} = D.cancel({pid, ref}, disp)
+    assert {10, 10} = waiting_and_pending(disp)
+
+    # Subscribe again and ask with a buffer smaller than the counter
+    {:ok, 0, disp} = D.subscribe([partition: 1], {pid, ref}, disp)
+    {:ok, 3, disp} = D.ask(5, 3, {pid, ref}, disp)
     assert {10, 5} = waiting_and_pending(disp)
     {:ok, 0, disp} = D.cancel({pid, ref}, disp)
     assert {10, 10} = waiting_and_pending(disp)
@@ -38,12 +65,12 @@ defmodule GenStage.PartitionDispatcherTest do
     disp = dispatcher(partitions: 1)
     {:ok, 0, disp} = D.subscribe([partition: 0], {pid, ref}, disp)
 
-    {:ok, 3, disp} = D.ask(3, {pid, ref}, disp)
+    {:ok, 3, disp} = D.ask(3, 0, {pid, ref}, disp)
     {:ok, [], disp} = D.dispatch([1], 1, disp)
     assert {2, 0} = waiting_and_pending(disp)
     assert_received {:"$gen_consumer", {_, ^ref}, [1]}
 
-    {:ok, 3, disp} = D.ask(3, {pid, ref}, disp)
+    {:ok, 3, disp} = D.ask(3, 0, {pid, ref}, disp)
     assert {5, 0} = waiting_and_pending(disp)
 
     {:ok, [9, 11], disp} = D.dispatch([2, 5, 6, 7, 8, 9, 11], 7, disp)
@@ -63,12 +90,12 @@ defmodule GenStage.PartitionDispatcherTest do
 
     {:ok, 0, disp} = D.subscribe([partition: :odd], {pid, ref}, disp)
 
-    {:ok, 3, disp} = D.ask(3, {pid, ref}, disp)
+    {:ok, 3, disp} = D.ask(3, 0, {pid, ref}, disp)
     {:ok, [], disp} = D.dispatch([1], 1, disp)
     assert {2, 0} = waiting_and_pending(disp)
     assert_received {:"$gen_consumer", {_, ^ref}, [1]}
 
-    {:ok, 3, disp} = D.ask(3, {pid, ref}, disp)
+    {:ok, 3, disp} = D.ask(3, 0, {pid, ref}, disp)
     assert {5, 0} = waiting_and_pending(disp)
 
     {:ok, [15, 17], disp} = D.dispatch([5, 7, 9, 11, 13, 15, 17], 7, disp)
@@ -94,8 +121,8 @@ defmodule GenStage.PartitionDispatcherTest do
     {:ok, 0, disp} = D.subscribe([partition: :even], {pid, even_ref}, disp)
     {:ok, 0, disp} = D.subscribe([partition: :odd], {pid, odd_ref}, disp)
 
-    {:ok, 4, disp} = D.ask(4, {pid, even_ref}, disp)
-    {:ok, 4, disp} = D.ask(4, {pid, odd_ref}, disp)
+    {:ok, 4, disp} = D.ask(4, 0, {pid, even_ref}, disp)
+    {:ok, 4, disp} = D.ask(4, 0, {pid, odd_ref}, disp)
     {:ok, [12], disp} = D.dispatch([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12], 12, disp)
 
     assert_received {:"$gen_consumer", {_, ^even_ref}, [2, 4, 8, 10]}
@@ -111,7 +138,7 @@ defmodule GenStage.PartitionDispatcherTest do
     ref = make_ref()
     {:ok, 0, disp} = D.subscribe([partition: 1], {pid, ref}, disp)
 
-    {:ok, 5, disp} = D.ask(5, {pid, ref}, disp)
+    {:ok, 5, disp} = D.ask(5, 0, {pid, ref}, disp)
     {:ok, [], disp} = D.dispatch([1, 2, 5, 6, 7], 5, disp)
     assert {0, 0} = waiting_and_pending(disp)
     refute_received {:"$gen_consumer", {_, ^ref}, _}
@@ -123,7 +150,7 @@ defmodule GenStage.PartitionDispatcherTest do
     pid = self()
     ref = make_ref()
     {:ok, 0, disp} = D.subscribe([partition: 0], {pid, ref}, disp)
-    {:ok, 5, disp} = D.ask(5, {pid, ref}, disp)
+    {:ok, 5, disp} = D.ask(5, 0, {pid, ref}, disp)
     assert {5, 0} = waiting_and_pending(disp)
     assert_received {:"$gen_consumer", {_, ^ref}, [1, 2, 5, 6, 7]}
 
@@ -137,13 +164,13 @@ defmodule GenStage.PartitionDispatcherTest do
     pid0 = self()
     ref0 = make_ref()
     {:ok, 0, disp} = D.subscribe([partition: 0], {pid0, ref0}, disp)
-    {:ok, 5, disp} = D.ask(5, {pid0, ref0}, disp)
+    {:ok, 5, disp} = D.ask(5, 0, {pid0, ref0}, disp)
     assert {5, 0} = waiting_and_pending(disp)
 
     pid1 = self()
     ref1 = make_ref()
     {:ok, 0, disp} = D.subscribe([partition: 1], {pid1, ref1}, disp)
-    {:ok, 5, disp} = D.ask(5, {pid1, ref1}, disp)
+    {:ok, 5, disp} = D.ask(5, 0, {pid1, ref1}, disp)
     assert {10, 0} = waiting_and_pending(disp)
 
     # Send all events to the same partition, half of them will be buffered
@@ -153,7 +180,7 @@ defmodule GenStage.PartitionDispatcherTest do
     assert_received {:"$gen_consumer", {_, ^ref0}, [1, 2]}
     assert_received {:"$gen_consumer", {_, ^ref0}, [5, 6, 7]}
 
-    {:ok, 5, disp} = D.ask(5, {pid0, ref0}, disp)
+    {:ok, 5, disp} = D.ask(5, 0, {pid0, ref0}, disp)
     assert {5, 0} = waiting_and_pending(disp)
     assert_received {:"$gen_consumer", {_, ^ref0}, [1, 2, 5, 6, 7]}
   end
@@ -164,7 +191,7 @@ defmodule GenStage.PartitionDispatcherTest do
     pid1 = self()
     ref1 = make_ref()
     {:ok, 0, disp} = D.subscribe([partition: 1], {pid1, ref1}, disp)
-    {:ok, 5, disp} = D.ask(5, {pid1, ref1}, disp)
+    {:ok, 5, disp} = D.ask(5, 0, {pid1, ref1}, disp)
     assert {5, 0} = waiting_and_pending(disp)
 
     pid0 = self()
@@ -190,7 +217,7 @@ defmodule GenStage.PartitionDispatcherTest do
 
     {:ok, 0, disp} = D.subscribe([partition: 0], {pid0, ref0}, disp)
     {:ok, 0, disp} = D.subscribe([partition: 1], {pid1, ref1}, disp)
-    {:ok, 3, disp} = D.ask(3, {pid1, ref1}, disp)
+    {:ok, 3, disp} = D.ask(3, 0, {pid1, ref1}, disp)
 
     {:ok, notify_disp} = D.info(:hello, disp)
     assert disp == notify_disp
@@ -212,13 +239,13 @@ defmodule GenStage.PartitionDispatcherTest do
 
     {:ok, 0, disp} = D.subscribe([partition: 0], {pid0, ref0}, disp)
     {:ok, 0, disp} = D.subscribe([partition: 1], {pid0, ref1}, disp)
-    {:ok, 3, disp} = D.ask(3, {pid1, ref1}, disp)
+    {:ok, 3, disp} = D.ask(3, 0, {pid1, ref1}, disp)
     {:ok, [], disp} = D.dispatch([1, 2, 5], 3, disp)
 
     {:ok, disp} = D.info(:hello, disp)
     refute_received :hello
 
-    {:ok, 5, _} = D.ask(5, {pid0, ref0}, disp)
+    {:ok, 5, _} = D.ask(5, 0, {pid0, ref0}, disp)
     assert_received :hello
   end
 
@@ -228,7 +255,7 @@ defmodule GenStage.PartitionDispatcherTest do
     disp = dispatcher(partitions: [:foo, :bar], hash: &{&1, :oops})
 
     {:ok, 0, disp} = D.subscribe([partition: :foo], {pid, ref}, disp)
-    {:ok, 3, disp} = D.ask(3, {pid, ref}, disp)
+    {:ok, 3, disp} = D.ask(3, 0, {pid, ref}, disp)
 
     assert_raise RuntimeError, ~r/unknown partition :oops/, fn ->
       D.dispatch([1, 2, 5], 3, disp)
@@ -240,7 +267,7 @@ defmodule GenStage.PartitionDispatcherTest do
     ref = make_ref()
     disp = dispatcher(partitions: [:foo, :bar], hash: fn _ -> :not_a_tuple end)
     {:ok, 0, disp} = D.subscribe([partition: :foo], {pid, ref}, disp)
-    {:ok, 3, disp} = D.ask(3, {pid, ref}, disp)
+    {:ok, 3, disp} = D.ask(3, 0, {pid, ref}, disp)
 
     assert_raise RuntimeError, ~r/the :hash function should return/, fn ->
       D.dispatch([1, 2, 5], 3, disp)


### PR DESCRIPTION
I updated the demand & partition dispatchers to account for the buffered events by adding an additional `buffer_size` parameter to the `ask` function. Therefore, if there are events in the buffer, they will be asked for. This solves the issue that happens when the producer buffers some events (because there are no consumers available), and then the consumers come back live. Previously the buffered events weren't sent because they were considered "already sent". Refer to the issue for the details of how the behavior reproduced: #311 