### PR TITLE
Fix documentation indentation

### DIFF
--- a/lib/gen_stage.ex
+++ b/lib/gen_stage.ex
@@ -921,18 +921,18 @@ defmodule GenStage do
 
   The producer can do one of these:
 
-    * Dispatch exactly as many events as `demand`.
+  * Dispatch exactly as many events as `demand`.
 
-    * Dispatch *more events* than `demand` - in this case, GenStage will
-      buffer the excess events. These events will be "used" by the
-      consumer/dispatcher next time demand is sent upstream. It's only
-      once the events in the buffer don't satisfy the demand anymore that
-      the `c:handle_demand/2` callback is invoked again. See the "Buffering"
-      section in the module documentation.
+  * Dispatch *more events* than `demand` - in this case, GenStage will
+    buffer the excess events. These events will be "used" by the
+    consumer/dispatcher next time demand is sent upstream. It's only
+    once the events in the buffer don't satisfy the demand anymore that
+    the `c:handle_demand/2` callback is invoked again. See the "Buffering"
+    section in the module documentation.
 
-    * Dispatch less events than `demand` - in this case, the producer is
-      responsible for storing the demand ("buffering demand") and then emitting
-      events when they are available.
+  * Dispatch less events than `demand` - in this case, the producer is
+    responsible for storing the demand ("buffering demand") and then emitting
+    events when they are available.
 
   See the "Demand" section in the module documentation.
 


### PR DESCRIPTION
Although I like highlighted code, markdown will be fine for this part of the documentation ;)

Looks like this right now on [hexdoc](https://hexdocs.pm/gen_stage/GenStage.html#c:handle_demand/2):
![image](https://github.com/user-attachments/assets/2c3ea4c1-5fb2-45e5-be4c-9b2971d13822)

Fixed version:
![image](https://github.com/user-attachments/assets/9dbd3dce-dc2b-492b-b9f4-eed1f2b3134a)
