### PR TITLE
Make the README the default hexdocs page

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -13,7 +13,8 @@ defmodule GenStage.Mixfile do
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       docs: [
-        main: "GenStage",
+        main: "readme",
+        extras: ["README.md"],
         source_ref: "v#{@version}",
         source_url: "https://github.com/elixir-lang/gen_stage"
       ]


### PR DESCRIPTION
Hey, this is just a suggestion to add the README as the default page in Hexdocs, too.

<img width="711" height="416" alt="image" src="https://github.com/user-attachments/assets/d24d2c7b-a92b-448a-8651-83dc88b5ae3a" />
